### PR TITLE
Adding default options to as_json method

### DIFF
--- a/lib/json_api_client/helpers/serializable.rb
+++ b/lib/json_api_client/helpers/serializable.rb
@@ -1,7 +1,7 @@
 module JsonApiClient
   module Helpers
     module Serializable
-      def as_json(options={})
+      def as_json(options=nil)
         attributes
       end
 


### PR DESCRIPTION
the `JsonApiClient::ResultSet` was throwing an exception `ArgumentError` when calling the `as_json`

``` ruby
@result = MyApp::Client::SomeClass.where(:type => 'this', :name => 'something').all
render :json => {:my_results => @result}
```

updated `as_json` with options defaults.
