### PR TITLE
Respond to

### DIFF
--- a/lib/json_api_client/helpers/attributable.rb
+++ b/lib/json_api_client/helpers/attributable.rb
@@ -34,8 +34,7 @@ module JsonApiClient
       end
 
       def respond_to?(method, include_private = false)
-        match = method.to_s.match(/^(.*[^=])=?$/)
-        if has_attribute?(match[1])
+        if (method.to_s =~ /^(.*)=$/) || has_attribute?(method)
           true
         else
           super
@@ -45,8 +44,8 @@ module JsonApiClient
       protected
 
       def method_missing(method, *args, &block)
-        if match = method.to_s.match(/^(.*)=$/)
-          set_attribute(match[1], args.first)
+        if method.to_s =~ /^(.*)=$/
+          set_attribute($1, args.first)
         elsif has_attribute?(method)
           attributes[method]
         else

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -148,6 +148,23 @@ class ResourceTest < MiniTest::Unit::TestCase
     assert_equal({asdf: "qwer", foo: "bar"}.stringify_keys, user.attributes)
   end
 
+  def test_dynamic_attribute_methods
+    user = User.new(foo: "bar")
+
+    assert user.respond_to? :foo
+    assert user.respond_to? :foo=
+    assert_equal(user.foo, "bar")
+
+    refute user.respond_to? :bar
+    assert user.respond_to? :bar=
+    user.bar = "baz"
+    assert user.respond_to? :bar
+
+    assert_raises NoMethodError do
+      user.quux
+    end
+  end
+
   def test_update
     stub_request(:put, "http://localhost:3000/api/1/users/6.json")
       .with(body: {


### PR DESCRIPTION
Currently a client resource will return false for .respond_to?(attribute) even though we dynamically add attribute methods with method_missing. This pull request adds a respond_to? method that correctly responds for dynamic attribute methods.

Borrowed from http://technicalpickles.com/posts/using-method_missing-and-respond_to-to-create-dynamic-methods/.
