### PR TITLE
Duplicate arguments in Query::Update to persist primary key

### DIFF
--- a/lib/json_api_client/query/update.rb
+++ b/lib/json_api_client/query/update.rb
@@ -4,7 +4,8 @@ module JsonApiClient
       self.request_method = :put
 
       def build_params(args)
-        @params = {klass.primary_key => args.dup.delete(klass.primary_key), klass.resource_name => args}
+        args = args.dup
+        @params = {klass.primary_key => args.delete(klass.primary_key), klass.resource_name => args}
       end
 
     end


### PR DESCRIPTION
Query::Update deletes the primary key for `def build_params`

``` ruby
def build_params(args)
  @params = {klass.primary_key => args.delete(klass.primary_key), klass.resource_name => args}
end
```

Instead we can duplicate the args before deleting

``` ruby
def build_params(args)
  args = args.dup
  @params = {klass.primary_key => args.delete(klass.primary_key), klass.resource_name => args}
end
```

and keep the id when resource.update_attributes completes.
