### PR TITLE
Use new Minitest::Test constant for tests

### DIFF
--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -23,7 +23,7 @@ module Namespaced
   end
 end
 
-class AssociationTest < MiniTest::Unit::TestCase
+class AssociationTest < Minitest::Test
 
   def test_load_has_one
     stub_request(:get, "http://localhost:3000/api/1/properties/1.json")

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -23,7 +23,7 @@ end
 class InheritedConnectionResource < CustomConnectionResource
 end
 
-class ConnectionTest < MiniTest::Unit::TestCase
+class ConnectionTest < Minitest::Test
 
   def test_basic
     assert_equal(NullConnection, CustomConnectionResource.connection_class)

--- a/test/unit/custom_endpoint_test.rb
+++ b/test/unit/custom_endpoint_test.rb
@@ -7,7 +7,7 @@ class Country < TestResource
 
 end
 
-class CustomEndpointTest < MiniTest::Unit::TestCase
+class CustomEndpointTest < Minitest::Test
 
   def test_collection_get
     stub_request(:get, "http://localhost:3000/api/1/countries/autocomplete.json?starts_with=bel")

--- a/test/unit/inheritance_test.rb
+++ b/test/unit/inheritance_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class InheritanceTest < MiniTest::Unit::TestCase
+class InheritanceTest < Minitest::Test
 
   def test_inherited_resource_url
     assert_equal "http://foo.com/inherited_endpoints", InheritedEndpoint.resource

--- a/test/unit/links_test.rb
+++ b/test/unit/links_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class LinksTest < MiniTest::Unit::TestCase
+class LinksTest < Minitest::Test
 
   def test_can_make_requests_for_data_if_linked_data_not_provided
     stub_request(:get, "http://localhost:3000/api/1/users/1.json")

--- a/test/unit/pagination_test.rb
+++ b/test/unit/pagination_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PaginationTest < MiniTest::Unit::TestCase
+class PaginationTest < Minitest::Test
 
   def test_no_meta_data
     stub_request(:get, "http://localhost:3000/api/1/users.json")

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ParserTest < MiniTest::Unit::TestCase
+class ParserTest < Minitest::Test
 
   def test_basic
     assert JsonApiClient::Parser.is_a?(Class)

--- a/test/unit/persistence_test.rb
+++ b/test/unit/persistence_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PersistenceTest < MiniTest::Unit::TestCase
+class PersistenceTest < Minitest::Test
 
   def test_standard_primary_key
     user = User.new

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class QueryTest < MiniTest::Unit::TestCase
+class QueryTest < Minitest::Test
 
   def test_find_query_with_params
     query = JsonApiClient::Query::Find.new(User, {foo: "bar", qwer: "asdf"})

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ResourceTest < MiniTest::Unit::TestCase
+class ResourceTest < Minitest::Test
 
   def test_basic
     assert User.is_a?(Class)

--- a/test/unit/scope_test.rb
+++ b/test/unit/scope_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ScopeTest < MiniTest::Unit::TestCase
+class ScopeTest < Minitest::Test
 
   def test_chaining
     scope = JsonApiClient::Scope.new(User).where(a: "b", c: "d")

--- a/test/unit/server_validations_test.rb
+++ b/test/unit/server_validations_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ServerValidationsTest < MiniTest::Unit::TestCase
+class ServerValidationsTest < Minitest::Test
 
   def test_update_validation_error
     stub_request(:put, "http://localhost:3000/api/1/users/6.json")

--- a/test/unit/status_test.rb
+++ b/test/unit/status_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class StatusTest < MiniTest::Unit::TestCase
+class StatusTest < Minitest::Test
 
   def test_server_responding_with_status_meta
     stub_request(:get, "http://localhost:3000/api/1/users/1.json")


### PR DESCRIPTION
Um, this might break for old versions of ruby if they don't have new minitest? Not sure...
