### PR TITLE
Ensure slurp keys are symbolized

### DIFF
--- a/lib/json_api_client/helpers/associable.rb
+++ b/lib/json_api_client/helpers/associable.rb
@@ -30,10 +30,8 @@ module JsonApiClient
         def path(params = nil)
           parts = [table_name]
           if params
-            slurp = params.slice(*prefix_params)
-            prefix_params.each do |param|
-              params.delete(param)
-            end
+            slurp = params.slice(*prefix_params).symbolize_keys
+            prefix_params.each { |param| params.delete(param) }
             parts.unshift(prefix_path % slurp)
           else
             parts.unshift(prefix_path)


### PR DESCRIPTION
If the parameter's key is not a symbol the path cannot be built.

Ex.
```ruby
class User < JsonApiClient::Resource
  belongs_to :organization
end 

user = User.create("id" => 12, "organization_id" => 10, "name" => "Gob Bluth")
#=> Exception, "Not all prefix parameters specified"

user = User.create(params.require(:user).permit(:id, :organization_id, :name))
#=> Exception, "Not all prefix parameters specified"
```

The exception is thrown on [line 35](https://github.com/jamesdphillips/json_api_client/blob/dc6e08313ec4cfbfdfd94486ae86f84bc7c1f087/lib/json_api_client/helpers/associable.rb#L35), in the example it equates to:
```"/organizations/%{id}/users" % { "organization_id" => 12 } #=> KeyError: key{organization_id} not found```
