### PR TITLE
Properly handle individual resource object

### DIFF
--- a/lib/json_api_client/result_set.rb
+++ b/lib/json_api_client/result_set.rb
@@ -12,7 +12,9 @@ module JsonApiClient
     alias_attribute :limit_value, :per_page
 
     def self.build(klass, data)
-      result_data = data.fetch(klass.table_name, [])
+      # Objects representing an individual resource are
+      # not necessarily wrapped in an Array; enforce wrapping
+      result_data = [data.fetch(klass.table_name, [])].flatten
       new(result_data.map {|attributes| klass.new(attributes) }).tap do |result_set|
         result_set.record_class = klass
         yield(result_set) if block_given?

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -28,6 +28,18 @@ class ResourceTest < MiniTest::Unit::TestCase
     assert_equal "Jeff Ching", user.name
   end
 
+  def test_find_with_individual_resource_representation
+    stub_request(:get, "http://localhost:3000/api/1/users/1.json")
+      .to_return(headers: {content_type: "application/json"}, body: {
+        users: {id: 1}
+      }.to_json)
+
+    users = User.find(1)
+
+    assert_equal 1, users.length
+    assert_equal 1, users.first.id
+  end
+
   def test_find_by_ids
     stub_request(:get, "http://localhost:3000/api/1/users.json")
       .with(query: {ids: "2,3"})


### PR DESCRIPTION
According to the JSON API specification at
http://jsonapi.org/format/#document-structure-individual-resource-representations,
representations of an individual resource are Objects
that are not necessarily wrapped in an Array.
