### PR TITLE
Pagination options

### DIFF
--- a/lib/json_api_client/parser.rb
+++ b/lib/json_api_client/parser.rb
@@ -25,7 +25,9 @@ module JsonApiClient
         result_set.total_entries = result_set.meta.fetch("total_entries") do
           result_set.length
         end
-        result_set.current_page = result_set.meta.fetch("current_page", 1)
+        result_set.current_page = result_set.meta.fetch("current_page") do
+          result_set.meta.fetch("page", 1)
+        end
 
         # can fall back to calculating via total entries and per_page
         result_set.total_pages = result_set.meta.fetch("total_pages") do

--- a/test/unit/pagination_test.rb
+++ b/test/unit/pagination_test.rb
@@ -125,4 +125,30 @@ class PaginationTest < MiniTest::Unit::TestCase
     assert_equal 3, users.per_page
   end
 
+  def test_can_handle_page_param
+    stub_request(:get, "http://localhost:3000/api/1/users.json")
+    .to_return(headers: {content_type: "application/json"}, body: {
+      users: [
+        {id: 1, name: "Jeff Ching", email_address: "ching.jeff@gmail.com"},
+        {id: 2, name: "Barry Bonds", email_address: "barry@bonds.com"},
+        {id: 3, name: "Hank Aaron", email_address: "hank@aaron.com"}
+      ],
+      meta: {
+        per_page: 3,
+        page: 2,
+        offset: 3,
+        total_entries: 10,
+        total_pages: 4
+      }
+    }.to_json)
+
+    users = User.all
+    assert_equal 3, users.length
+    assert_equal 3, users.per_page
+    assert_equal 2, users.current_page
+    assert_equal 3, users.offset
+    assert_equal 10, users.total_entries
+    assert_equal 4, users.total_pages
+  end
+
 end


### PR DESCRIPTION
Optionally handle meta: page as well as meta: current_page

We're querying with the page param, so it makes sense that we'd be able to read page from the meta (keep reading current_page for backwards compatibility)