### PR TITLE
require addressable/uri

### DIFF
--- a/lib/json_api_client/query/base.rb
+++ b/lib/json_api_client/query/base.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 module JsonApiClient
   module Query
     class Base


### PR DESCRIPTION
If you don't require uri, this class is broken.

```
[1] pry(#<CreditCardsController>)> e
=> #<NameError: uninitialized constant JsonApiClient::Query::Base::Addressable>
[2] pry(#<CreditCardsController>)> e.backtrace
=> ["/Users/dplummer/.rvm/gems/ruby-2.2.0/gems/json_api_client-0.8.0/lib/json_api_client/query/base.rb:19:in `build_path'",
 "/Users/dplummer/.rvm/gems/ruby-2.2.0/gems/json_api_client-0.8.0/lib/json_api_client/query/base.rb:11:in `initialize'",
 "/Users/dplummer/.rvm/gems/ruby-2.2.0/gems/json_api_client-0.8.0/lib/json_api_client/resource.rb:32:in `new'",
 "/Users/dplummer/.rvm/gems/ruby-2.2.0/gems/json_api_client-0.8.0/lib/json_api_client/resource.rb:32:in `find'",
```