### PR TITLE
Fixes #47 - filtering per RC3 spec

### DIFF
--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'Build client libraries compliant with specification defined by jsonapi.org'
 
   s.add_dependency "activesupport"
-  s.add_dependency "faraday", '~> 0.8.0'
+  s.add_dependency "faraday", '>= 0.8.0'
   s.add_dependency "faraday_middleware", '~> 0.9'
   s.add_dependency "addressable", '~> 2.2'
 

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -7,13 +7,14 @@ module JsonApiClient
       def initialize(klass)
         @klass = klass
         @pagination_params = {}
+        @filters = {}
         @base_params = {}
         @includes = []
         @orders = []
       end
 
       def where(conditions = {})
-        @base_params.merge!(conditions)
+        @filters.merge!(conditions)
         self
       end
 
@@ -48,6 +49,7 @@ module JsonApiClient
       def params
         @base_params
           .merge(@pagination_params)
+          .merge(filter_params)
           .merge(includes_params)
           .merge(order_params)
       end
@@ -65,6 +67,10 @@ module JsonApiClient
 
       def includes_params
         @includes.empty? ? {} : {include: @includes.join(",")}
+      end
+
+      def filter_params
+        @filters.empty? ? {} : {filter: @filters}
       end
 
       def order_params

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -8,7 +8,6 @@ module JsonApiClient
         @klass = klass
         @pagination_params = {}
         @filters = {}
-        @base_params = {}
         @includes = []
         @orders = []
       end
@@ -47,9 +46,8 @@ module JsonApiClient
       end
 
       def params
-        @base_params
-          .merge(@pagination_params)
-          .merge(filter_params)
+        filter_params
+          .merge(pagination_params)
           .merge(includes_params)
           .merge(order_params)
       end
@@ -64,6 +62,8 @@ module JsonApiClient
       end
 
       private
+
+      attr_reader :pagination_params
 
       def includes_params
         @includes.empty? ? {} : {include: @includes.join(",")}

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -2,6 +2,15 @@ require 'test_helper'
 
 class QueryBuilderTest < MiniTest::Unit::TestCase
 
+  def test_can_filter
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {filter: {author: '5'}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    articles = Article.where(author: '5').to_a
+  end
+
   def test_can_specify_nested_includes
     stub_request(:get, "http://example.com/articles")
       .with(query: {include: "comments.author"})


### PR DESCRIPTION
`Comment.where(author: '5')` translates to `/comments?filter[author]=5` per http://jsonapi.org/recommendations/#filtering