### PR TITLE
Passing in entire document instead of just the links to the paginator

### DIFF
--- a/lib/json_api_client/helpers/paginatable.rb
+++ b/lib/json_api_client/helpers/paginatable.rb
@@ -11,3 +11,4 @@ module JsonApiClient
     end
   end
 end
+

--- a/lib/json_api_client/paginating/paginator.rb
+++ b/lib/json_api_client/paginating/paginator.rb
@@ -39,6 +39,7 @@ module JsonApiClient
       def total_entries
         per_page * total_pages
       end
+      alias_method :total_count, :total_entries
 
       def offset
         per_page * (current_page - 1)

--- a/lib/json_api_client/paginating/paginator.rb
+++ b/lib/json_api_client/paginating/paginator.rb
@@ -2,10 +2,10 @@ module JsonApiClient
   module Paginating
     class Paginator
       attr_reader :params, :result_set, :links
-      def initialize(result_set, links)
+      def initialize(result_set, data)
         @params = params_for_uri(result_set.uri)
         @result_set = result_set
-        @links = links
+        @links = data['links']
       end
 
       def next

--- a/lib/json_api_client/parsers/parser.rb
+++ b/lib/json_api_client/parsers/parser.rb
@@ -40,7 +40,7 @@ module JsonApiClient
         end
 
         def handle_pagination(result_set, data)
-          result_set.pages = result_set.record_class.paginator.new(result_set, data.fetch("links", {}))
+          result_set.pages = result_set.record_class.paginator.new(result_set, data)
         end
 
         def handle_included(result_set, data)

--- a/lib/json_api_client/result_set.rb
+++ b/lib/json_api_client/result_set.rb
@@ -12,7 +12,7 @@ module JsonApiClient
                   :links
 
     # pagination methods are handled by the paginator
-    def_delegators :pages, :total_pages, :total_entries, :offset, :per_page, :current_page, :limit_value, :next_page, :previous_page, :out_of_bounds?
+    def_delegators :pages, :total_pages, :total_entries, :total_count, :offset, :per_page, :current_page, :limit_value, :next_page, :previous_page, :out_of_bounds?
 
     def self.build(klass, data)
       # Objects representing an individual resource are


### PR DESCRIPTION
Passing in the entire document allows custom paginators to leverage meta data values like ("total_count" or "total_pages").