### PR TITLE
fix sort param to remove illegal "+" from asc requests

### DIFF
--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -121,11 +121,11 @@ module JsonApiClient
           case arg
           when Hash
             arg.map do |k, v|
-              operator = (v == :desc ? "-" : "+")
+              operator = (v == :desc ? "-" : "")
               "#{operator}#{k}"
             end
           else
-            "+#{arg}"
+            "#{arg}"
           end
         end.flatten
       end

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -40,7 +40,7 @@ class QueryBuilderTest < MiniTest::Test
 
   def test_can_sort_asc
     stub_request(:get, "http://example.com/articles")
-      .with(query: {sort: "+foo"})
+      .with(query: {sort: "foo"})
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
@@ -50,7 +50,7 @@ class QueryBuilderTest < MiniTest::Test
 
   def test_sort_defaults_to_asc
     stub_request(:get, "http://example.com/articles")
-      .with(query: {sort: "+foo"})
+      .with(query: {sort: "foo"})
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
@@ -70,7 +70,7 @@ class QueryBuilderTest < MiniTest::Test
 
   def test_can_sort_multiple
     stub_request(:get, "http://example.com/articles")
-      .with(query: {sort: "-foo,+bar"})
+      .with(query: {sort: "-foo,bar"})
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
@@ -79,7 +79,7 @@ class QueryBuilderTest < MiniTest::Test
 
   def test_can_sort_mixed
     stub_request(:get, "http://example.com/articles")
-      .with(query: {sort: "-foo,+bar"})
+      .with(query: {sort: "-foo,bar"})
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)


### PR DESCRIPTION
http://jsonapi.org/format/#fetching-sorting doesn't use + signs, and in fact requires them to be absent. This fixes the issue.