### PR TITLE
Fetching nested records

### DIFF
--- a/lib/json_api_client/helpers/associable.rb
+++ b/lib/json_api_client/helpers/associable.rb
@@ -30,12 +30,8 @@ module JsonApiClient
         def path(params = nil)
           parts = [table_name]
           if params
-            filters = params.fetch(:filter, params)
-            slurp = filters.slice(*prefix_params)
-            prefix_params.each do |param|
-              filters.delete(param)
-            end
-            parts.unshift(prefix_path % slurp.symbolize_keys)
+            path_params = params.delete(:path) || params
+            parts.unshift(prefix_path % path_params.symbolize_keys)
           else
             parts.unshift(prefix_path)
           end

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -16,15 +16,9 @@ module JsonApiClient
       end
 
       def where(conditions = {})
-        filters = {}
-        conditions.each do |k, v|
-          if klass.prefix_params.include?(k)
-            @path_params[k] = v
-          else
-            filters[k] = v
-          end
-        end
-        @filters.merge!(filters)
+        # pull out any path params here
+        @path_params.merge!(conditions.slice(*klass.prefix_params))
+        @filters.merge!(conditions.except(*klass.prefix_params))
         self
       end
 

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -269,22 +269,37 @@ class AssociationTest < MiniTest::Test
 
   def test_find_belongs_to_params_unchanged
     stub_request(:get, "http://example.com/foos/1/specifieds")
-          .to_return(headers: {
-                         content_type: "application/vnd.api+json"
-                     }, body: {
-                          data: [
-                              {
-                                  id: 1,
-                                  name: "Jeff Ching",
-                                  bars: [{id: 1, attributes: {address: "123 Main St."}}]
-                              }
-                          ]
-                      }.to_json)
+      .to_return(headers: {
+        content_type: "application/vnd.api+json"
+      }, body: {
+        data: [
+          {
+            id: 1,
+            name: "Jeff Ching",
+            bars: [{id: 1, attributes: {address: "123 Main St."}}]
+          }
+        ]
+      }.to_json)
 
     specifieds = Specified.where(foo_id: 1)
     assert_equal({path: {foo_id: 1}}, specifieds.params)
     specifieds.all
     assert_equal({path: {foo_id: 1}}, specifieds.params)
+  end
+
+  def test_nested_create
+    stub_request(:post, "http://example.com/foos/1/specifieds")
+      .to_return(headers: {
+        content_type: "application/vnd.api+json"
+      }, body: {
+        data: {
+          id: 1,
+          name: "Jeff Ching",
+          bars: [{id: 1, attributes: {address: "123 Main St."}}]
+        }
+      }.to_json)
+
+    specified = Specified.create(foo_id: 1)
   end
 
 end

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -267,4 +267,24 @@ class AssociationTest < MiniTest::Test
     })
   end
 
+  def test_find_belongs_to_params_unchanged
+    stub_request(:get, "http://example.com/foos/1/specifieds")
+          .to_return(headers: {
+                         content_type: "application/vnd.api+json"
+                     }, body: {
+                          data: [
+                              {
+                                  id: 1,
+                                  name: "Jeff Ching",
+                                  bars: [{id: 1, attributes: {address: "123 Main St."}}]
+                              }
+                          ]
+                      }.to_json)
+
+    specifieds = Specified.where(foo_id: 1)
+    assert_equal({path: {foo_id: 1}}, specifieds.params)
+    specifieds.all
+    assert_equal({path: {foo_id: 1}}, specifieds.params)
+  end
+
 end


### PR DESCRIPTION
Fixes #76 

We'll collect path params earlier in the query builder rather than trying to pull them out at request time from the filters hash