### PR TITLE
Limit data sent on creates/updates

### DIFF
--- a/lib/json_api_client/helpers/associable.rb
+++ b/lib/json_api_client/helpers/associable.rb
@@ -4,7 +4,7 @@ module JsonApiClient
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :associations
+        class_attribute :associations, instance_accessor: false
         self.associations = []
 
         include Associations::BelongsTo
@@ -45,7 +45,7 @@ module JsonApiClient
       protected
 
       def load_associations(params)
-        associations.each do |association|
+        self.class.associations.each do |association|
           if params.has_key?(association.attr_name.to_s)
             set_attribute(association.attr_name, association.parse(params[association.attr_name.to_s]))
           end

--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -1,7 +1,6 @@
 module JsonApiClient
   module Helpers
     module DynamicAttributes
-      extend ActiveSupport::Concern
 
       def attributes
         @attributes

--- a/lib/json_api_client/helpers/initializable.rb
+++ b/lib/json_api_client/helpers/initializable.rb
@@ -4,7 +4,7 @@ module JsonApiClient
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :initializers
+        class_attribute :initializers, instance_accessor: false
         self.initializers = []
       end
 
@@ -15,7 +15,7 @@ module JsonApiClient
       end
 
       def initialize(params = {})
-        initializers.each do |initializer|
+        self.class.initializers.each do |initializer|
           if initializer.respond_to?(:call)
             initializer.call(self, params)
           else

--- a/lib/json_api_client/helpers/linkable.rb
+++ b/lib/json_api_client/helpers/linkable.rb
@@ -4,7 +4,7 @@ module JsonApiClient
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :linker
+        class_attribute :linker, instance_accessor: false
         self.linker = Linking::Links
 
         # the links for this resource
@@ -13,7 +13,7 @@ module JsonApiClient
         initializer do |obj, params|
           links = params && params.delete("links")
           links ||= {}
-          obj.links = obj.linker.new(links)
+          obj.links = obj.class.linker.new(links)
         end
       end
 

--- a/lib/json_api_client/helpers/paginatable.rb
+++ b/lib/json_api_client/helpers/paginatable.rb
@@ -4,7 +4,7 @@ module JsonApiClient
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :paginator
+        class_attribute :paginator, instance_accessor: false
         self.paginator = Paginating::Paginator
       end
 

--- a/lib/json_api_client/helpers/parsable.rb
+++ b/lib/json_api_client/helpers/parsable.rb
@@ -4,7 +4,7 @@ module JsonApiClient
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :parser
+        class_attribute :parser, instance_accessor: false
         self.parser = Parsers::Parser
       end
 

--- a/lib/json_api_client/helpers/queryable.rb
+++ b/lib/json_api_client/helpers/queryable.rb
@@ -8,7 +8,7 @@ module JsonApiClient
           extend Forwardable
           def_delegators :new_scope, :where, :order, :includes, :select, :all, :paginate, :page, :first, :find
         end
-        class_attribute :connection_class, :connection_object, :connection_options, :query_builder
+        class_attribute :connection_class, :connection_object, :connection_options, :query_builder, instance_accessor: false
         self.connection_class = Connection
         self.connection_options = {}
         self.query_builder = Query::Builder

--- a/lib/json_api_client/helpers/relatable.rb
+++ b/lib/json_api_client/helpers/relatable.rb
@@ -4,7 +4,7 @@ module JsonApiClient
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :relationship_linker
+        class_attribute :relationship_linker, instance_accessor: false
         self.relationship_linker = Relationships::Relations
 
         # the relationships for this resource
@@ -13,7 +13,7 @@ module JsonApiClient
         initializer do |obj, params|
           relationships = params && params.delete("relationships")
           relationships ||= {}
-          obj.relationships = obj.relationship_linker.new(relationships)
+          obj.relationships = obj.class.relationship_linker.new(relationships)
         end
       end
 

--- a/lib/json_api_client/helpers/requestable.rb
+++ b/lib/json_api_client/helpers/requestable.rb
@@ -5,7 +5,7 @@ module JsonApiClient
 
       included do
         attr_accessor :last_result_set, :errors
-        class_attribute :requestor_class
+        class_attribute :requestor_class, instance_accessor: false
         self.requestor_class = Query::Requestor
       end
 

--- a/lib/json_api_client/helpers/serializable.rb
+++ b/lib/json_api_client/helpers/serializable.rb
@@ -1,17 +1,21 @@
 module JsonApiClient
   module Helpers
     module Serializable
-      RESERVED = ['id', 'type', 'links', 'meta', 'relationships']
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :read_only_attributes, instance_accessor: false
+        self.read_only_attributes = ['id', 'type', 'links', 'meta', 'relationships']
+      end
 
       def serializable_hash
         attributes.slice('id', 'type').tap do |h|
           relationships.serializable_hash.tap do |r|
             h['relationships'] = r unless r.empty?
           end
-          h['attributes'] = attributes.except(*RESERVED)
+          h['attributes'] = attributes.except(*self.class.read_only_attributes)
         end
       end
-      alias data serializable_hash
 
     end
   end

--- a/lib/json_api_client/helpers/serializable.rb
+++ b/lib/json_api_client/helpers/serializable.rb
@@ -3,21 +3,15 @@ module JsonApiClient
     module Serializable
       RESERVED = ['id', 'type', 'links', 'meta', 'relationships']
 
-      # def as_json(options=nil)
-      #   attributes.slice(*RESERVED).tap do |h|
-      #     h['attributes'] = serialized_attributes
-      #   end
-      # end
-
-      def data
-        attributes.slice(*RESERVED).tap do |h|
-          h['attributes'] = serialized_attributes
+      def serializable_hash
+        attributes.slice('id', 'type').tap do |h|
+          relationships.serializable_hash.tap do |r|
+            h['relationships'] = r unless r.empty?
+          end
+          h['attributes'] = attributes.except(*RESERVED)
         end
       end
-
-      def serialized_attributes
-        attributes.except(*RESERVED)
-      end
+      alias data serializable_hash
 
     end
   end

--- a/lib/json_api_client/query/requestor.rb
+++ b/lib/json_api_client/query/requestor.rb
@@ -10,13 +10,13 @@ module JsonApiClient
       # expects a record
       def create(record)
         request(:post, klass.path(record.attributes), {
-          data: record.data
+          data: record.serializable_hash
         })
       end
 
       def update(record)
         request(:patch, resource_path(record.attributes), {
-          data: record.data
+          data: record.serializable_hash
         })
       end
 

--- a/lib/json_api_client/relationships/relations.rb
+++ b/lib/json_api_client/relationships/relations.rb
@@ -11,6 +11,12 @@ module JsonApiClient
         attributes.present?
       end
 
+      def serializable_hash
+        Hash[attributes.map do |k, v|
+          [k, v.slice("data")]
+        end]
+      end
+
       protected
 
       def set_attribute(name, value)

--- a/test/unit/serializing_test.rb
+++ b/test/unit/serializing_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class SerializingTest < MiniTest::Test
+
+  class LimitedField < TestResource
+    self.read_only_attributes += ['foo']
+  end
+
+  def test_update_data_only_includes_relationship_data
+    stub_request(:get, "http://example.com/articles")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [{
+          type: "articles",
+          id: "1",
+          attributes: {
+            title: "JSON API paints my bikeshed!"
+          },
+          relationships: {
+            author: {
+              links: {
+                self: "http://example.com/posts/1/relationships/author",
+                related: "http://example.com/posts/1/author"
+              },
+              data: {
+                type: "people",
+                id: "9"
+              }
+            }
+          }
+        }],
+        included: [{
+          type: "people",
+          id: "9",
+          attributes: {
+            name: "Jeff"
+          }
+        }]
+      }.to_json)
+
+    articles = Article.all
+    article = articles.first
+
+    expected = {
+      "type" => "articles",
+      "id" => "1",
+      "attributes" => {
+        "title" => "JSON API paints my bikeshed!"
+      },
+      "relationships" => {
+        "author" => {
+          "data" => {
+            "type" => "people",
+            "id" => "9"
+          }
+        }
+      }
+    }
+    assert_equal expected, article.serializable_hash
+  end
+
+  def test_skips_read_only_attributes
+    resource = LimitedField.new({
+      id: 1,
+      foo: "bar",
+      qwer: "asdf"
+    })
+
+    expected = {
+      'id' => 1,
+      'type' => 'limited_fields',
+      'attributes' => {
+        'qwer' => 'asdf'
+      }
+    }
+    assert_equal(expected, resource.serializable_hash)
+  end
+
+end


### PR DESCRIPTION
Adding the ability to specify read only attributes for a class. It's a class attribute so it should be inheritable if for some reason you want to set it on a base class.

```
class MyResource < JsonApiClient::Resource
  self.read_only_attributes += ["created_at"]
end
```

This fixes #79, #57, #44