### PR TITLE
overwrite the attributes_for_serialization

### DIFF
--- a/lib/json_api_client/helpers/serializable.rb
+++ b/lib/json_api_client/helpers/serializable.rb
@@ -13,8 +13,14 @@ module JsonApiClient
           relationships.serializable_hash.tap do |r|
             h['relationships'] = r unless r.empty?
           end
-          h['attributes'] = attributes.except(*self.class.read_only_attributes)
+          h['attributes'] = attributes_for_serialization
         end
+      end
+
+      protected
+
+      def attributes_for_serialization
+        attributes.except(*self.class.read_only_attributes)
       end
 
     end

--- a/test/unit/serializing_test.rb
+++ b/test/unit/serializing_test.rb
@@ -17,6 +17,15 @@ class SerializingTest < MiniTest::Test
     end
   end
 
+  class InheritedCustomSerializerAttributes < TestResource
+
+    protected
+
+    def attributes_for_serialization
+      super.except(:foo)
+    end
+  end
+
   def test_update_data_only_includes_relationship_data
     stub_request(:get, "http://example.com/articles")
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
@@ -96,6 +105,22 @@ class SerializingTest < MiniTest::Test
       }
     }
     assert_equal expected, resource.serializable_hash
+  end
+
+  def test_inherited_attributes_for_serialization
+    resource = InheritedCustomSerializerAttributes.new({
+      foo: "bar",
+      id: 1234,
+      qwer: "asdf"
+    })
+
+    expected = {
+      "type" => "inherited_custom_serializer_attributes",
+      "id" => 1234,
+      "attributes" => {
+        "qwer" => "asdf"
+      }
+    }
   end
 
 end

--- a/test/unit/serializing_test.rb
+++ b/test/unit/serializing_test.rb
@@ -6,6 +6,17 @@ class SerializingTest < MiniTest::Test
     self.read_only_attributes += ['foo']
   end
 
+  class CustomSerializerAttributes < TestResource
+
+    protected
+
+    def attributes_for_serialization
+      {
+        foo: "bar"
+      }
+    end
+  end
+
   def test_update_data_only_includes_relationship_data
     stub_request(:get, "http://example.com/articles")
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
@@ -73,6 +84,18 @@ class SerializingTest < MiniTest::Test
       }
     }
     assert_equal(expected, resource.serializable_hash)
+  end
+
+  def test_can_specify_attributes_for_serialization
+    resource = CustomSerializerAttributes.new
+
+    expected = {
+      "type" => "custom_serializer_attributes",
+      "attributes" => {
+        "foo" => "bar"
+      }
+    }
+    assert_equal expected, resource.serializable_hash
   end
 
 end


### PR DESCRIPTION
I don't want to bake in the idea of create vs. update attributes - instead I'll add a hook that you can use to customize what attributes are returned for serialization.