### PR TITLE
Appropriately handle responses with no content.

### DIFF
--- a/lib/json_api_client/parsers/parser.rb
+++ b/lib/json_api_client/parsers/parser.rb
@@ -3,7 +3,8 @@ module JsonApiClient
     class Parser
       class << self
         def parse(klass, response)
-          data = response.body
+          data = response.body || {}
+
           ResultSet.new.tap do |result_set|
             result_set.record_class = klass
             result_set.uri = response.env[:url]

--- a/lib/json_api_client/parsers/parser.rb
+++ b/lib/json_api_client/parsers/parser.rb
@@ -3,7 +3,7 @@ module JsonApiClient
     class Parser
       class << self
         def parse(klass, response)
-          data = response.body || {}
+          data = response.body.present? ? response.body : {}
 
           ResultSet.new.tap do |result_set|
             result_set.record_class = klass

--- a/test/unit/destroying_test.rb
+++ b/test/unit/destroying_test.rb
@@ -13,6 +13,15 @@ class DestroyingTest < MiniTest::Test
     assert_equal(false, user.persisted?)
   end
 
+  def test_destroy_no_content
+    stub_request(:delete, "http://example.com/users/6")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: nil)
+
+    user = User.new(id: 6)
+    assert(user.destroy, "successful deletion should return truish value")
+    assert_equal(false, user.persisted?)
+  end
+
   def test_destroy_failure
     stub_request(:get, "http://example.com/users/1")
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {

--- a/test/unit/error_collector_test.rb
+++ b/test/unit/error_collector_test.rb
@@ -29,6 +29,25 @@ class ErrorCollectorTest < MiniTest::Test
     assert_equal [], article.errors["title"], "expected to be able to inspect errors that are not present and return nil"
   end
 
+  def test_can_handle_no_content
+    stub_request(:post, "http://example.com/articles")
+      .with(headers: {content_type: "application/vnd.api+json", accept: "application/vnd.api+json"}, body: {
+          data: {
+            type: "articles",
+            attributes: {
+              title: "Rails is Omakase"
+            }
+          }
+        }.to_json)
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: nil)
+
+    article = Article.create({
+      title: "Rails is Omakase"
+    })
+    assert_equal false, article.errors.present?
+    assert_equal [], article.errors["title"], "expected to be able to inspect errors that are not present and return nil"
+  end
+
   def test_can_handle_errors
     stub_request(:post, "http://example.com/articles")
       .with(headers: {content_type: "application/vnd.api+json", accept: "application/vnd.api+json"}, body: {


### PR DESCRIPTION
As I understand the JSON API spec (see http://jsonapi.org/format/#crud-deleting as an example) returning no content in the body is a perfectly valid thing to do in a number of instances. Previously this would cause errors when trying to construct a ResultSet instance from the response.