### PR TITLE
If the page param is invalid, default it

### DIFF
--- a/lib/json_api_client/scope.rb
+++ b/lib/json_api_client/scope.rb
@@ -2,6 +2,8 @@ module JsonApiClient
   class Scope
     attr_reader :klass, :params
 
+    FIRST_PAGE_NUMBER = 1
+
     def initialize(klass)
       @klass = klass
       @params = {}
@@ -24,11 +26,12 @@ module JsonApiClient
     end
 
     def page(number)
+      number = [number.to_i, FIRST_PAGE_NUMBER].max
       where(page: number)
     end
 
     def first
-      paginate(page: 1, per_page: 1).to_a.first
+      paginate(page: FIRST_PAGE_NUMBER, per_page: 1).to_a.first
     end
 
     def build

--- a/test/unit/scope_test.rb
+++ b/test/unit/scope_test.rb
@@ -20,4 +20,18 @@ class ScopeTest < MiniTest::Unit::TestCase
     assert_equal({a: "b", c: "d", e: "f", order: "name desc", per_page: 30, page: 2}, scope.params)
   end
 
+  def test_invalid_pages
+    scope = JsonApiClient::Scope.new(User)
+    assert_equal(1, scope.page(1).params[:page])
+    assert_equal(1, scope.page("1").params[:page])
+    assert_equal(88, scope.page("88").params[:page])
+    assert_equal(1, scope.page("abc").params[:page])
+    assert_equal(1, scope.page("-1").params[:page])
+    assert_equal(1, scope.page("0").params[:page])
+    assert_equal(1, scope.page(0).params[:page])
+    assert_equal(1, scope.page(-1).params[:page])
+    assert_equal(1, scope.page(-99).params[:page])
+    assert_equal(15, scope.page(15).params[:page])
+  end
+
 end


### PR DESCRIPTION
If the page param is invalid, default it instead of passing on the bad value.

A spambot might send page=abc to your pages, and we should handle that better.  Even page=0 will fail server-side.