### PR TITLE
refactore read_only_attributes

### DIFF
--- a/lib/json_api_client/helpers/serializable.rb
+++ b/lib/json_api_client/helpers/serializable.rb
@@ -1,12 +1,6 @@
 module JsonApiClient
   module Helpers
     module Serializable
-      extend ActiveSupport::Concern
-
-      included do
-        class_attribute :read_only_attributes, instance_accessor: false
-        self.read_only_attributes = ['id', 'type', 'links', 'meta', 'relationships']
-      end
 
       def serializable_hash
         attributes.slice('id', 'type').tap do |h|
@@ -17,10 +11,14 @@ module JsonApiClient
         end
       end
 
+      def read_only_attributes
+        [:id, :type, :links, :meta, :relationships]
+      end
+
       protected
 
       def attributes_for_serialization
-        attributes.except(*self.class.read_only_attributes)
+        attributes.except(*self.read_only_attributes.map(&:to_s))
       end
 
     end


### PR DESCRIPTION
i think read_only_attributes should be an instance method cause it will be more flexible.
for example, if server allows to set country only on user creation you solve it on client side like this:
```ruby
class User < JsonApiClient::Resource

  def read_only_attributes
    if self.persisted?
      super + [:country]
    else
      super
    end
  end

end
```