### PR TITLE
fix relationships in serializable_hash

### DIFF
--- a/lib/json_api_client/helpers/serializable.rb
+++ b/lib/json_api_client/helpers/serializable.rb
@@ -10,7 +10,7 @@ module JsonApiClient
 
       def serializable_hash
         attributes.slice('id', 'type').tap do |h|
-          relationships.serializable_hash.tap do |r|
+          relationships_for_serialization.tap do |r|
             h['relationships'] = r unless r.empty?
           end
           h['attributes'] = attributes_for_serialization
@@ -26,6 +26,10 @@ module JsonApiClient
 
       def attributes_for_serialization
         attributes.except(*self.class.read_only_attributes).slice(*changed)
+      end
+
+      def relationships_for_serialization
+        relationships.serializable_hash
       end
 
     end

--- a/lib/json_api_client/relationships/relations.rb
+++ b/lib/json_api_client/relationships/relations.rb
@@ -14,8 +14,8 @@ module JsonApiClient
 
       def serializable_hash
         Hash[attributes_for_serialization.map do |k, v|
-               [k, v.slice("data")]
-             end]
+               [k, v.slice("data")]  if v.has_key?("data")
+             end.compact]
       end
 
       def attributes_for_serialization
@@ -30,6 +30,8 @@ module JsonApiClient
           {data: value.as_relation}
         when Array
           {data: value.map(&:as_relation)}
+        when NilClass
+          {data: nil}
         else
           value
         end

--- a/test/unit/updating_test.rb
+++ b/test/unit/updating_test.rb
@@ -2,6 +2,12 @@ require 'test_helper'
 
 class UpdatingTest < MiniTest::Test
 
+  class Author < TestResource
+    def relationships_for_serialization
+      super.except('reader')
+    end
+  end
+
   def setup
     super
     stub_request(:get, "http://example.com/articles/1")
@@ -279,6 +285,248 @@ class UpdatingTest < MiniTest::Test
     ]
     article.set_all_dirty!
     assert article.save
+  end
+
+  def test_can_not_update_read_only_relationship
+    stub_request(:get, "http://example.com/authors/1")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "authors",
+                            id: "1",
+                            attributes: {
+                                name: "John Doe"
+                            }
+                        }
+                    }.to_json)
+
+    authors = Author.find(1)
+    author = authors.first
+
+    stub_request(:patch, "http://example.com/authors/1")
+        .with(headers: {
+                  content_type: "application/vnd.api+json",
+                  accept: "application/vnd.api+json"
+              }, body: {
+                   data: {
+                       id: "1",
+                       type: "authors",
+                       attributes: {}
+                   }
+               }.to_json)
+        .to_return(headers: {
+                       status: 200,
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "authors",
+                            id: "1",
+                            attributes: {
+                                name: "John Doe"
+                            }
+                        }
+                    }.to_json)
+
+    author.relationships.reader = Person.new(id: "1")
+    assert author.save
+  end
+
+  def test_can_not_update_empty_relationship
+    stub_request(:get, "http://example.com/authors/1")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "authors",
+                            id: "1",
+                            attributes: {
+                                name: "John Doe"
+                            },
+                            relationships: {
+                                editor: {
+                                    links: {
+                                        self: "/articles/1/links/editor",
+                                        related: "/articles/1/editor"
+                                    }
+                                }
+                            }
+                        }
+                    }.to_json)
+
+    authors = Author.find(1)
+    author = authors.first
+
+    stub_request(:patch, "http://example.com/authors/1")
+        .with(headers: {
+                  content_type: "application/vnd.api+json",
+                  accept: "application/vnd.api+json"
+              }, body: {
+                   data: {
+                       id: "1",
+                       type: "authors",
+                       attributes: {}
+                   }
+               }.to_json)
+        .to_return(headers: {
+                       status: 200,
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "authors",
+                            id: "1",
+                            attributes: {
+                                name: "John Doe"
+                            },
+                            relationships: {
+                                editor: {
+                                    links: {
+                                        self: "/articles/1/links/editor",
+                                        related: "/articles/1/editor"
+                                    }
+                                }
+                            }
+                        }
+                    }.to_json)
+
+    assert author.save
+  end
+
+  def test_can_remove_has_one_relationship
+    stub_request(:get, "http://example.com/authors/1")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "authors",
+                            id: "1",
+                            attributes: {
+                                name: "John Doe"
+                            },
+                            relationships: {
+                                editor: {
+                                    links: {
+                                        self: "/articles/1/links/editor",
+                                        related: "/articles/1/editor"
+                                    },
+                                    data: {id: '2', type: 'editors'}
+                                }
+                            }
+                        }
+                    }.to_json)
+
+    authors = Author.find(1)
+    author = authors.first
+
+    stub_request(:patch, "http://example.com/authors/1")
+        .with(headers: {
+                  content_type: "application/vnd.api+json",
+                  accept: "application/vnd.api+json"
+              }, body: {
+                   data: {
+                       id: "1",
+                       type: "authors",
+                       relationships: {
+                           editor: {
+                               data: nil
+                           }
+                       },
+                       attributes: {}
+                   }
+               }.to_json)
+        .to_return(headers: {
+                       status: 200,
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "authors",
+                            id: "1",
+                            relationships: {
+                                editor: {
+                                    links: {
+                                        self: "/articles/1/links/editor",
+                                        related: "/articles/1/editor"
+                                    }
+                                }
+                            },
+                            attributes: {
+                                name: "John Doe"
+                            }
+                        }
+                    }.to_json)
+
+    author.relationships.editor = nil
+    assert author.save
+  end
+
+  def test_can_remove_has_many_relationship
+    stub_request(:get, "http://example.com/authors/1")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "authors",
+                            id: "1",
+                            attributes: {
+                                name: "John Doe"
+                            },
+                            relationships: {
+                                articles: {
+                                    links: {
+                                        self: "/articles/1/links/articles",
+                                        related: "/articles/1/articles"
+                                    },
+                                    data: [
+                                        {id: '2', type: 'articles'},
+                                        {id: '3', type: 'articles'}
+                                    ]
+                                }
+                            }
+                        }
+                    }.to_json)
+
+    authors = Author.find(1)
+    author = authors.first
+
+    stub_request(:patch, "http://example.com/authors/1")
+        .with(headers: {
+                  content_type: "application/vnd.api+json",
+                  accept: "application/vnd.api+json"
+              }, body: {
+                   data: {
+                       id: "1",
+                       type: "authors",
+                       relationships: {
+                           articles: {
+                               data: []
+                           }
+                       },
+                       attributes: {}
+                   }
+               }.to_json)
+        .to_return(headers: {
+                       status: 200,
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "authors",
+                            id: "1",
+                            relationships: {
+                                articles: {
+                                    links: {
+                                        self: "/articles/1/links/articles",
+                                        related: "/articles/1/articles"
+                                    }
+                                }
+                            },
+                            attributes: {
+                                name: "John Doe"
+                            }
+                        }
+                    }.to_json)
+
+    author.relationships.articles = []
+    assert author.save
   end
 
 end


### PR DESCRIPTION
fix situations: 
* when client send relationships that have no data.
```ruby
article = Article.find(1).first
```
will retrieve data like:
```ruby
         data: {
            id: "1",
            type: "articles",
            relationships: {
              author: {
                links: {
                  self: "/articles/1/links/author",
                  related: "/articles/1/author"
                }
              }
            },
            attributes: {
              title: "Rails is Omakase"
            }
```
and
```ruby
article.save
```
will send updated data:
```ruby
          data: {
            id: "1",
            type: "articles",
            attributes: {
              title: "Rails is Omakase"
            }
```
* when client try to remove relationship (nullify it)
```ruby
author = Author.find(1).first
author.relationships.editor = nil
author.save
```
will send request like:
```ruby
                   data: {
                       id: "1",
                       type: "authors",
                       relationships: {
                           editor: {
                               data: nil
                           }
                       },
                       attributes: {
                           name: "John Doe"
                       }
                   }
```

* added ability to set read only relationships
```ruby
class Author < TestResource
    def relationships_for_serialization
      super.except('reader')
    end
  end

author = Author.find(1).first
author.relationships.reader = Person.new(id: "1")
author.relationships.editor = Person.new(id: "2")
author.save
```
will send request like:
```ruby
                   data: {
                       id: "1",
                       type: "authors",
                       relationships: {
                           editor: {
                               id: "2",
                               type: "persons"
                       },
                       attributes: {
                           name: "John Doe"
                       }
                   }
```