### PR TITLE
Use HashWithIndifferentAccess for metadata

### DIFF
--- a/lib/json_api_client/parser.rb
+++ b/lib/json_api_client/parser.rb
@@ -15,7 +15,7 @@ module JsonApiClient
       private
 
       def handle_meta(result_set, data)
-        result_set.meta = data.fetch("meta", {})
+        result_set.meta = HashWithIndifferentAccess.new(data.fetch("meta", nil))
       end
 
       def handle_pagination(result_set, data)

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -6,4 +6,30 @@ class ParserTest < MiniTest::Unit::TestCase
     assert JsonApiClient::Parser.is_a?(Class)
   end
 
+  def test_meta_is_accessible_indifferently
+    result = JsonApiClient::ResultSet.new
+    args = [result, mock_response]
+    JsonApiClient::Parser.send('handle_meta', *args)
+    assert_equal(200, result.meta["status"])
+    assert_equal(200, result.meta[:status])
+    assert_equal(1, result.meta["page"])
+    assert_equal(1, result.meta[:page])
+    assert_equal(9999, result.meta["total_pages"])
+    assert_equal(9999, result.meta[:total_pages])
+  end
+
+  private
+
+  def mock_response
+    {
+        "meta": {
+            "per-page": 10,
+            "page": 1,
+            "status": 200,
+            "total_pages": 9999,
+            "errors": nil
+        }
+    }.stringify_keys!
+  end
+
 end

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -22,12 +22,12 @@ class ParserTest < MiniTest::Unit::TestCase
 
   def mock_response
     {
-        "meta": {
-            "per-page": 10,
-            "page": 1,
-            "status": 200,
-            "total_pages": 9999,
-            "errors": nil
+        "meta" => {
+            "per-page" => 10,
+            "page" => 1,
+            "status" => 200,
+            "total_pages" => 9999,
+            "errors" => nil
         }
     }.stringify_keys!
   end


### PR DESCRIPTION
json_api_client consistently returns strings, but json_api_resource wanted to use symbols in some cases and now we have them mixed together sometimes.  This means application-side bugs creeped in because we expected string but got symbol and vice-versa.  This will solve that in a simple way, and then consumers of json_api_client can use whatever their preference is - symbol or string.