### PR TITLE
add active_support callbacks

### DIFF
--- a/lib/json_api_client/helpers.rb
+++ b/lib/json_api_client/helpers.rb
@@ -15,5 +15,6 @@ module JsonApiClient
     autoload :Requestable, 'json_api_client/helpers/requestable'
     autoload :Schemable, 'json_api_client/helpers/schemable'
     autoload :Serializable, 'json_api_client/helpers/serializable'
+    autoload :Callbacks, 'json_api_client/helpers/callbacks'
   end
 end

--- a/lib/json_api_client/helpers/callbacks.rb
+++ b/lib/json_api_client/helpers/callbacks.rb
@@ -1,0 +1,46 @@
+module JsonApiClient
+  module Helpers
+    module Callbacks
+      extend ActiveSupport::Concern
+
+      included do
+        include ActiveSupport::Callbacks
+        define_callbacks :save, :destroy, :create, :update
+      end
+
+      module ClassMethods
+
+        [:save, :destroy, :create, :update].each do |operation|
+          [:before, :after, :around].each do |type|
+            define_method "#{type}_#{operation}" do |*methods, &block|
+
+              if block
+                set_callback operation, type, *methods, block
+              else
+                set_callback operation, type, *methods
+              end
+
+            end
+          end
+        end
+
+      end
+
+      def save
+        run_callbacks :save do
+          run_callbacks (persisted? ? :update : :create) do
+            super
+          end
+        end
+      end
+
+      def destroy
+        run_callbacks :destroy do
+          super
+        end
+      end
+
+
+    end
+  end
+end

--- a/test/unit/destroying_test.rb
+++ b/test/unit/destroying_test.rb
@@ -2,6 +2,14 @@ require 'test_helper'
 
 class DestroyingTest < MiniTest::Test
 
+  class CallbackTest < TestResource
+    include JsonApiClient::Helpers::Callbacks
+    attr_accessor :foo
+    after_destroy do
+      self.foo = 10
+    end
+  end
+
   def test_destroy
     stub_request(:delete, "http://example.com/users/6")
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
@@ -47,6 +55,17 @@ class DestroyingTest < MiniTest::Test
 
     assert_equal(false, user.destroy, "failed deletion should return falsy value")
     assert_equal(true, user.persisted?, "user should still be persisted because destroy failed")
+  end
+
+  def test_callbacks
+    stub_request(:delete, "http://example.com/callback_tests/6")
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+                                                                          data: []
+                                                                      }.to_json)
+
+    callback_test = CallbackTest.new(id: 6)
+    callback_test.destroy
+    assert_equal(10, callback_test.foo)
   end
 
 end

--- a/test/unit/updating_test.rb
+++ b/test/unit/updating_test.rb
@@ -2,6 +2,18 @@ require 'test_helper'
 
 class UpdatingTest < MiniTest::Test
 
+  class CallbackTest < TestResource
+    include JsonApiClient::Helpers::Callbacks
+    before_update do
+      self.foo = 10
+    end
+
+    after_save :after_save_method
+    def after_save_method
+      self.bar = 100
+    end
+  end
+
   def setup
     super
     stub_request(:get, "http://example.com/articles/1")
@@ -279,6 +291,54 @@ class UpdatingTest < MiniTest::Test
     ]
     article.set_all_dirty!
     assert article.save
+  end
+
+  def test_callbacks_on_update
+    stub_request(:get, "http://example.com/callback_tests/1")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "callback_tests",
+                            id: "1",
+                            attributes: {
+                                foo: 1,
+                                bar: 1
+                            }
+                        }
+                    }.to_json)
+
+    callback_test = CallbackTest.find(1).first
+
+    stub_request(:patch, "http://example.com/callback_tests/1")
+        .with(headers: {
+                  content_type: "application/vnd.api+json",
+                  accept: "application/vnd.api+json"
+              }, body: {
+                   data: {
+                       id: "1",
+                       type: "callback_tests",
+                       attributes: {
+                           foo: 10
+                       }
+                   }
+               }.to_json)
+        .to_return(headers: {
+                       status: 200,
+                       content_type: "application/vnd.api+json"
+                   }, body: {
+                        data: {
+                            type: "callback_tests",
+                            id: "1",
+                            attributes: {
+                                foo: 10,
+                                bar: 1
+                            }
+                        }
+                    }.to_json)
+
+    assert callback_test.save
+    assert_equal 100, callback_test.bar
   end
 
 end


### PR DESCRIPTION
add optional support of callbacks
you need to include `JsonApiClient::Helpers::Callbacks`

callbacks: `save, create, update, destroy`
types: `before, around, after`
in addition add some helpers so we can use activerecord-like syntax:
```ruby
class User < BaseResource
  include JsonApiClient::Helpers::Callbacks
  before_save do
    self.full_name = "#{self.first_name} #{self.last_name}"
  end
  after_create :log_response

  def log_response
    # some code here
  end
end
```

