### PR TITLE
move dirty_attributes feature to separated helper module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 
 gem "activesupport", as_version
 gem 'addressable', '~> 2.2'
+gem "activemodel"
 
 # 3.2 now requires the minitest gem
 if as_version =~ /3\.2\./

--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'Build client libraries compliant with specification defined by jsonapi.org'
 
   s.add_dependency "activesupport", '>= 3.2.0'
+  s.add_dependency "activemodel"
   s.add_dependency "faraday", '>= 0.8.0'
   s.add_dependency "faraday_middleware", '~> 0.9'
   s.add_dependency "addressable", '~> 2.2'

--- a/lib/json_api_client/helpers.rb
+++ b/lib/json_api_client/helpers.rb
@@ -16,5 +16,6 @@ module JsonApiClient
     autoload :Schemable, 'json_api_client/helpers/schemable'
     autoload :Serializable, 'json_api_client/helpers/serializable'
     autoload :Callbacks, 'json_api_client/helpers/callbacks'
+    autoload :DirtyAttributes, 'json_api_client/helpers/dirty_attributes'
   end
 end

--- a/lib/json_api_client/helpers/attributable.rb
+++ b/lib/json_api_client/helpers/attributable.rb
@@ -15,7 +15,6 @@ module JsonApiClient
         def load(params)
           new(params).tap do |resource|
             resource.mark_as_persisted!
-            resource.clear_changes_information
           end
         end
 

--- a/lib/json_api_client/helpers/dirty_attributes.rb
+++ b/lib/json_api_client/helpers/dirty_attributes.rb
@@ -1,0 +1,64 @@
+require 'active_model/attribute_methods'
+require 'active_model/dirty'
+
+module JsonApiClient
+  module Helpers
+    module DirtyAttributes
+      extend ActiveSupport::Concern
+
+      included do
+        include ActiveModel::Dirty
+      end
+
+      module ClassMethods
+        def load(params)
+          super.tap do |resource|
+            resource.clear_changes!
+          end
+        end
+      end
+
+      def clear_changes!
+        # call private `clear_changes_information`
+        clear_changes_information
+      end
+
+      def set_all_attributes_dirty
+        attributes.each do |k, v|
+          set_attribute_was(k, v)
+        end
+      end
+
+      def set_all_dirty!
+        set_all_attributes_dirty
+        relationships.set_all_attributes_dirty if relationships
+      end
+
+      protected
+
+      def attributes_for_serialization
+        super.slice(*changed)
+      end
+
+      def method_missing(method, *args, &block)
+        if method.to_s =~ /^(.*)=$/
+          set_attribute($1, args.first)
+        elsif has_attribute?(method)
+          attributes[method]
+        elsif method.to_s =~ /^(.*)_changed\?$/
+          has_attribute?($1) ? attribute_changed?($1) : nil
+        elsif method.to_s =~ /^(.*)_was$/
+          has_attribute?($1) ? attribute_was($1) : nil
+        else
+          super
+        end
+      end
+
+      def set_attribute(name, value)
+        attribute_will_change!(name) if value != attributes[name]
+        super
+      end
+
+    end
+  end
+end

--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -35,53 +35,6 @@ module JsonApiClient
         attributes.has_key?(attr_name)
       end
 
-      def changed?
-        changed_attributes.present?
-      end
-
-      def changed
-        changed_attributes.keys
-      end
-
-      def changed_attributes
-        @changed_attributes ||= ActiveSupport::HashWithIndifferentAccess.new
-      end
-
-      def clear_changes_information
-        @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
-      end
-
-      def set_all_attributes_dirty
-        attributes.each do |k, v|
-          set_attribute_was(k, v)
-        end
-      end
-
-      def attribute_will_change!(attr)
-        return if attribute_changed?(attr)
-        set_attribute_was(attr, attributes[attr])
-      end
-
-      def set_attribute_was(attr, value)
-        begin
-          value = value.duplicable? ? value.clone : value
-          changed_attributes[attr] = value
-        rescue TypeError, NoMethodError
-        end
-      end
-
-      def attribute_was(attr) # :nodoc:
-        attribute_changed?(attr) ? changed_attributes[attr] : attributes[attr]
-      end
-
-      def attribute_changed?(attr)
-        changed.include?(attr.to_s)
-      end
-
-      def attribute_change(attr)
-        [changed_attributes[attr], attributes[attr]] if attribute_changed?(attr)
-      end
-
       protected
 
       def method_missing(method, *args, &block)
@@ -89,10 +42,6 @@ module JsonApiClient
           set_attribute($1, args.first)
         elsif has_attribute?(method)
           attributes[method]
-        elsif method.to_s =~ /^(.*)_changed\?$/
-          has_attribute?($1) ? attribute_changed?($1) : nil
-        elsif method.to_s =~ /^(.*)_was$/
-          has_attribute?($1) ? attribute_was($1) : nil
         else
           super
         end
@@ -103,7 +52,6 @@ module JsonApiClient
       end
 
       def set_attribute(name, value)
-        attribute_will_change!(name) if value != attributes[name]
         attributes[name] = value
       end
 

--- a/lib/json_api_client/helpers/serializable.rb
+++ b/lib/json_api_client/helpers/serializable.rb
@@ -17,15 +17,10 @@ module JsonApiClient
         end
       end
 
-      def set_all_dirty!
-        set_all_attributes_dirty
-        relationships.set_all_attributes_dirty if relationships
-      end
-
       protected
 
       def attributes_for_serialization
-        attributes.except(*self.class.read_only_attributes).slice(*changed)
+        attributes.except(*self.class.read_only_attributes)
       end
 
       def relationships_for_serialization

--- a/lib/json_api_client/relationships.rb
+++ b/lib/json_api_client/relationships.rb
@@ -1,6 +1,7 @@
 module JsonApiClient
   module Relationships
     autoload :Relations, "json_api_client/relationships/relations"
+    autoload :RelationsWithDirty, "json_api_client/relationships/relations_with_dirty"
     autoload :TopLevelRelations, "json_api_client/relationships/top_level_relations"
   end
 end

--- a/lib/json_api_client/relationships/relations.rb
+++ b/lib/json_api_client/relationships/relations.rb
@@ -5,7 +5,6 @@ module JsonApiClient
 
       def initialize(relations)
         self.attributes = relations
-        clear_changes_information
       end
 
       def present?
@@ -18,14 +17,14 @@ module JsonApiClient
              end.compact]
       end
 
-      def attributes_for_serialization
-        attributes.slice(*changed)
-      end
-
       protected
 
+      def attributes_for_serialization
+        attributes
+      end
+
       def set_attribute(name, value)
-        value = case value
+        attributes[name] = case value
         when JsonApiClient::Resource
           {data: value.as_relation}
         when Array
@@ -35,8 +34,6 @@ module JsonApiClient
         else
           value
         end
-        attribute_will_change!(name) if value != attributes[name]
-        attributes[name] = value
       end
 
     end

--- a/lib/json_api_client/relationships/relations_with_dirty.rb
+++ b/lib/json_api_client/relationships/relations_with_dirty.rb
@@ -1,0 +1,34 @@
+module JsonApiClient
+  module Relationships
+    class RelationsWithDirty < Relations
+      include Helpers::DirtyAttributes
+
+      def initialize(relations)
+        super
+        clear_changes_information
+      end
+
+      protected
+
+      def attributes_for_serialization
+        super.slice(*changed)
+      end
+
+      def set_attribute(name, value)
+        value = case value
+                  when JsonApiClient::Resource
+                    {data: value.as_relation}
+                  when Array
+                    {data: value.map(&:as_relation)}
+                  when NilClass
+                    {data: nil}
+                  else
+                    value
+                end
+        attribute_will_change!(name) if value != attributes[name]
+        attributes[name] = value
+      end
+
+    end
+  end
+end

--- a/test/unit/editing_test.rb
+++ b/test/unit/editing_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Author < TestResource
+  include JsonApiClient::Helpers::DirtyAttributes
+  self.relationship_linker = JsonApiClient::Relationships::RelationsWithDirty
 end
 
 class EditingTest < MiniTest::Test

--- a/test/unit/serializing_test.rb
+++ b/test/unit/serializing_test.rb
@@ -28,48 +28,6 @@ class SerializingTest < MiniTest::Test
 
   def test_update_data_only_includes_relationship_data
     stub_request(:get, "http://example.com/articles")
-      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
-        data: [{
-          type: "articles",
-          id: "1",
-          attributes: {
-            title: "JSON API paints my bikeshed!"
-          },
-          relationships: {
-            author: {
-              links: {
-                self: "http://example.com/posts/1/relationships/author",
-                related: "http://example.com/posts/1/author"
-              },
-              data: {
-                type: "people",
-                id: "9"
-              }
-            }
-          }
-        }],
-        included: [{
-          type: "people",
-          id: "9",
-          attributes: {
-            name: "Jeff"
-          }
-        }]
-      }.to_json)
-
-    articles = Article.all
-    article = articles.first
-
-    expected = {
-      "type" => "articles",
-      "id" => "1",
-      "attributes" => {}
-    }
-    assert_equal expected, article.serializable_hash
-  end
-
-  def test_update_data_only_includes_relationship_data_with_all_attributes_dirty
-    stub_request(:get, "http://example.com/articles")
         .to_return(headers: {
                        content_type: "application/vnd.api+json"},
                    body: {
@@ -103,7 +61,6 @@ class SerializingTest < MiniTest::Test
 
     articles = Article.all
     article = articles.first
-    article.set_all_dirty!
 
     expected = {
         "type" => "articles",


### PR DESCRIPTION
@Fivell convince me that dirty attributes feature should be optional so i've moved it to it's own helper.
so we can add dirty tracking like this:
```ruby
class BaseResourceWithDirty < BaseResource
  include JsonApiClient::Helpers::DirtyAttributes # this row will turn on dirty tracking for attributes
  self.relationship_linker = JsonApiClient::Relationships::RelationsWithDirty # this row will turn on dirty tracking for relationships
end
```

@chingor13 what do you think about it?