### PR TITLE
0.x

### DIFF
--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -11,8 +11,12 @@ module JsonApiClient
     end
 
     class ServerError < ApiError
+      attr_reader :uri
+      def initialize(uri)
+        @uri = uri
+      end
       def message
-        "Internal server error"
+        "Internal server error at: #{uri.to_s}"
       end
     end
 

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -18,9 +18,9 @@ module JsonApiClient
       def handle_status(code, env)
         case code
         when 404
-          raise Errors::NotFound, env[:uri]
+          raise Errors::NotFound, env[:url]
         when 500..599
-          raise Errors::ServerError, env
+          raise Errors::ServerError, env[:url]
         end
       end
     end

--- a/lib/json_api_client/version.rb
+++ b/lib/json_api_client/version.rb
@@ -1,3 +1,3 @@
 module JsonApiClient
-  VERSION = "0.9.3"
+  VERSION = "0.9.4"
 end

--- a/test/unit/status_test.rb
+++ b/test/unit/status_test.rb
@@ -1,9 +1,12 @@
 require 'test_helper'
 
 class StatusTest < MiniTest::Unit::TestCase
+  def setup
+    @api_url = "http://localhost:3000/api/1/users/1.json"
+  end
 
   def test_server_responding_with_status_meta
-    stub_request(:get, "http://localhost:3000/api/1/users/1.json")
+    stub_request(:get, @api_url)
       .to_return(headers: {content_type: "application/json"}, body: {
         meta: {
           status: 500,
@@ -11,13 +14,14 @@ class StatusTest < MiniTest::Unit::TestCase
         }
       }.to_json)
 
-    assert_raises JsonApiClient::Errors::ServerError do
+    server_error = assert_raises JsonApiClient::Errors::ServerError do
       users = User.find(1)
     end
+    assert_equal server_error.message, "Internal server error at: #{@api_url}"
   end
 
   def test_server_responding_with_http_status
-    stub_request(:get, "http://localhost:3000/api/1/users/1.json")
+    stub_request(:get, @api_url)
       .to_return(headers: {
         content_type: "text/plain"
       }, 
@@ -30,20 +34,22 @@ class StatusTest < MiniTest::Unit::TestCase
   end
 
   def test_server_responding_with_404_status
-    stub_request(:get, "http://localhost:3000/api/1/users/1.json")
+    stub_request(:get, @api_url)
       .to_return(headers: {
         content_type: "text/plain"
       }, 
       status: 404,
       body: "something irrelevant")
 
-    assert_raises JsonApiClient::Errors::NotFound do
+    not_found_exception = assert_raises JsonApiClient::Errors::NotFound do
       users = User.find(1)
     end
+
+    assert_equal not_found_exception.message, "Couldn't find resource at: #{@api_url}"
   end
 
   def test_server_responding_with_404_status_meta
-    stub_request(:get, "http://localhost:3000/api/1/users/1.json")
+    stub_request(:get, @api_url)
       .to_return(headers: {content_type: "application/json"}, body: {
         meta: {
           status: 404,


### PR DESCRIPTION
Errors::NotFound exception message was not reporting the uri in the error message.
Adding the uri to Errors::ServerError as well as it will greatly help identify/reproduce issues on REST service.
Updating tests suite to cover above changes 