### PR TITLE
correct request when assign nil to attribute

### DIFF
--- a/lib/json_api_client/helpers/dirty.rb
+++ b/lib/json_api_client/helpers/dirty.rb
@@ -62,7 +62,7 @@ module JsonApiClient
       end
 
       def set_attribute(name, value)
-        attribute_will_change!(name) if value != attributes[name]
+        attribute_will_change!(name) if value != attributes[name] || !attributes.has_key?(name)
         super
       end
 

--- a/test/unit/creation_test.rb
+++ b/test/unit/creation_test.rb
@@ -14,6 +14,9 @@ class CreationTest < MiniTest::Test
     end
   end
 
+  class Author < TestResource
+  end
+
   def setup
     super
     stub_request(:post, "http://example.com/articles")
@@ -54,6 +57,43 @@ class CreationTest < MiniTest::Test
     assert article.save
     assert article.persisted?
     assert_equal "1", article.id
+  end
+
+  def test_correct_create_with_nil_attirbute_value
+    stub_request(:post, "http://example.com/authors")
+        .with(headers: {
+                  content_type: "application/vnd.api+json",
+                  accept: "application/vnd.api+json"
+              },
+              body: {
+                  data: {
+                      type: "authors",
+                      attributes: {
+                          name: "John Doe",
+                          description: nil
+                      }
+                  }
+              }.to_json)
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   },
+                   body: {
+                       data: {
+                           type: "authors",
+                           id: "1",
+                           attributes: {
+                               name: "John Doe",
+                               description: nil
+                           }
+                       }
+                   }.to_json)
+
+    author = Author.new({
+                             name: "John Doe",
+                             description: nil
+                         })
+
+    assert author.save
   end
 
   def test_callbacks_on_update


### PR DESCRIPTION
i think when you attribute always should be added to changed_attribute if there is no such key in attributes.keys
this PR fix such behaviour