### PR TITLE
property should not add default value if default is nil

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -267,7 +267,7 @@ module JsonApiClient
       end
       self.attributes = params.merge(self.class.default_attributes)
       self.class.schema.each_property do |property|
-        attributes[property.name] = property.default unless attributes.has_key?(property.name)
+        attributes[property.name] = property.default unless attributes.has_key?(property.name) || property.default.nil?
       end
     end
 

--- a/test/unit/schemable_test.rb
+++ b/test/unit/schemable_test.rb
@@ -17,6 +17,15 @@ end
 
 class SchemableTest < MiniTest::Test
 
+  def test_default_attributes
+    resource = SchemaResource.new
+
+    assert resource.attributes.has_key?(:a), ':a should be in attributes'
+    assert resource.attributes.has_key?(:b), ':b should be in attributes'
+    refute resource.attributes.has_key?(:c), ':c should not be in attributes'
+    refute resource.attributes.has_key?(:d), ':d should not be in attributes'
+  end
+
   def test_defines_fields
     resource = SchemaResource.new
 


### PR DESCRIPTION
after PR #103 properties update `changed_attributes` even if no default value assigned
for example if `User` have balance field which that client can't change but it converted to a string (for fixed precision)
we have some code:
```ruby
class User < Base
  property :balance, type: :float
end

user = User.new
user.name = 'John Doe'
user.save # will send {data: {type: 'users', attributes: {name: 'John Doe', balance: nil} } }
```
that is wrong.
this PR fixes this issue
