### PR TITLE
add test for fetching relations that does not exist

### DIFF
--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -380,4 +380,78 @@ class AssociationTest < MiniTest::Test
     specified = Specified.create(foo_id: 1)
   end
 
+  def test_load_nil_has_one_through_related_link
+    stub_request(:get, "http://example.com/properties/1")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   },
+                   body: {
+                       data: [
+                           {
+                               id: 1,
+                               attributes: {
+                                   address: "123 Main St."
+                               },
+                               relationships: {
+                                   owner: {
+                                       links: {
+                                         related: "http://example.com/properties/1/relationships/owner"
+                                       }
+                                   }
+                               }
+                           }
+                       ]
+                   }.to_json)
+
+    stub_request(:get, "http://example.com/properties/1/relationships/owner")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   },
+                   body: {
+                       links: {
+                           related: "http://example.com/properties/1/relationships/owner"
+                       },
+                       data: nil
+                   }.to_json)
+
+    property = Property.find(1).first
+    assert_equal nil, property.owner
+  end
+
+  def test_load_empty_has_many_through_related_link
+    stub_request(:get, "http://example.com/owners/1")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   },
+                   body: {
+                       data: {
+                               id: 1,
+                               attributes: {
+                                   name: "Jeff Ching",
+                               },
+                               relationships: {
+                                   properties: {
+                                       links: {
+                                           related: "http://example.com/owners/1/relationships/properties"
+                                       }
+                                   }
+                               }
+                           }
+                   }.to_json)
+
+    stub_request(:get, "http://example.com/owners/1/relationships/properties")
+        .to_return(headers: {
+                       content_type: "application/vnd.api+json"
+                   },
+                   body: {
+                       links: {
+                           related: "http://example.com/owners/1/relationships/properties"
+                       },
+                       data: []
+                   }.to_json)
+
+    owner = Owner.find(1).first
+    assert_equal [], owner.properties
+  end
+
 end


### PR DESCRIPTION
test for has_many passes, but for has_one fails with error:
```
Minitest::UnexpectedError: NoMethodError: undefined method `slice' for nil:NilClass
    /home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:52:in `parameters_from_resource'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:69:in `block in handle_data'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:68:in `map'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:68:in `handle_data'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:12:in `block in parse'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:8:in `tap'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:8:in `parse'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/query/requestor.rb:63:in `request'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/query/requestor.rb:34:in `linked'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/associations/base_association.rb:18:in `data'
    /home/senid/projects/forked/json_api_client/lib/json_api_client/resource.rb:405:in `method_missing'
    /home/senid/projects/forked/json_api_client/test/unit/association_test.rb:418:in `test_load_nil_has_one_through_related_link'
/home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:52:in `parameters_from_resource'
/home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:69:in `block in handle_data'
/home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:68:in `map'
/home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:68:in `handle_data'
/home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:12:in `block in parse'
/home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:8:in `tap'
/home/senid/projects/forked/json_api_client/lib/json_api_client/parsers/parser.rb:8:in `parse'
/home/senid/projects/forked/json_api_client/lib/json_api_client/query/requestor.rb:63:in `request'
/home/senid/projects/forked/json_api_client/lib/json_api_client/query/requestor.rb:34:in `linked'
/home/senid/projects/forked/json_api_client/lib/json_api_client/associations/base_association.rb:18:in `data'
/home/senid/projects/forked/json_api_client/lib/json_api_client/resource.rb:405:in `method_missing'
/home/senid/projects/forked/json_api_client/test/unit/association_test.rb:418:in `test_load_nil_has_one_through_related_link'
```