### PR TITLE
allow null error attributes

### DIFF
--- a/lib/json_api_client/error_collector.rb
+++ b/lib/json_api_client/error_collector.rb
@@ -12,7 +12,7 @@ module JsonApiClient
       end
 
       def about
-        attrs.fetch(:links, {})[:about]
+        (attrs[:links] || {})[:about]
       end
 
       def status
@@ -48,11 +48,11 @@ module JsonApiClient
       end
 
       def source
-        attrs.fetch(:source, {})
+        attrs[:source] || {}
       end
 
       def meta
-        MetaData.new(attrs.fetch(:meta, {}))
+        MetaData.new(attrs[:meta] || {})
       end
 
       protected

--- a/test/unit/error_collector_test.rb
+++ b/test/unit/error_collector_test.rb
@@ -79,9 +79,13 @@ class ErrorCollectorTest < MiniTest::Test
           },
           {
             id: "33333",
+            links: nil,
             status: "400",
             code: "1338",
-            title: "Title already taken"
+            title: "Title already taken",
+            detail: nil,
+            source: nil,
+            meta: nil
           }
         ]
       }.to_json)


### PR DESCRIPTION
some server implementations send null values for `source` etc. this results in corresponding `nil` values in the error `attrs` hash.

unfortunately `fetch` does not return the default value when the hash value is `nil`. so when it returns `nil` for `source` we get the exception: `undefined method `fetch' for nil:NilClass` when trying to treat it as a hash.

the solution is to use `attrs[:source] || {}` instead of `attrs.fetch(:source, {})`. this is also necessary for a few other error attributes.