### PR TITLE
Read pagination-related variables from an API response correctly

### DIFF
--- a/lib/json_api_client/paginating/paginator.rb
+++ b/lib/json_api_client/paginating/paginator.rb
@@ -27,7 +27,7 @@ module JsonApiClient
       def total_pages
         if links["last"]
           last_params = params_for_uri(links["last"])
-          last_params.fetch("page") do
+          last_params.fetch("page[number]") do
             current_page
           end.to_i
         else
@@ -46,13 +46,13 @@ module JsonApiClient
       end
 
       def per_page
-        params.fetch("per_page") do
+        params.fetch("page[size]") do
           result_set.length
         end.to_i
       end
 
       def current_page
-        params.fetch("page", 1).to_i
+        params.fetch("page[number]", 1).to_i
       end
 
       def out_of_bounds?


### PR DESCRIPTION
At the moment it looks for `per_page` and `page` options in the query string of the `last` pagination URL, which will never exist.

JSON API spec says pagination should be done with either `page[number]` and `page[size]`, or `page[offset]` and `page[limit]`, or `page[cursor]`.

I'm not super familiar with the latter two, but the typical approach is number and size - and this change means pagination can now be done correctly. (Previously did not work at all - `current_page` and `total_pages` were always 1.)