### PR TITLE
Handle error values explicitly set to null.

### DIFF
--- a/lib/json_api_client/error_collector.rb
+++ b/lib/json_api_client/error_collector.rb
@@ -12,7 +12,8 @@ module JsonApiClient
       end
 
       def about
-        attrs.fetch(:links, {})[:about]
+        res = attrs.fetch(:links, {})
+        res ? res[:about] : {}
       end
 
       def status
@@ -48,7 +49,8 @@ module JsonApiClient
       end
 
       def source
-        attrs.fetch(:source, {})
+        res = attrs.fetch(:source, {})
+        res ? res : {}
       end
 
       def meta


### PR DESCRIPTION
JSONAPI states that error objects may contain quite a few data items. It does not say that if they are nil they should not be included. Either way they should be handled properly if they are explicitly set to nil. Currently, if they are there and set to nil an exception will be thrown on nil.fetch for about and source. I threw the rest into the test just for completeness.