### PR TITLE
Set attributes in initializer through <attribute>= so it can be overridden w/ a setter.

### DIFF
--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -11,7 +11,7 @@ module JsonApiClient
 
         return @attributes unless attrs.present?
         attrs.each do |key, value|
-          set_attribute(key, value)
+          send("#{key}=", value)
         end
       end
 

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -334,6 +334,11 @@ module JsonApiClient
       relationships.set_all_attributes_dirty if relationships
     end
 
+    def valid?(context = nil)
+      context ||= (new_record? ? :create : :update)
+      super(context)
+    end
+
     # Commit the current changes to the resource to the remote server.
     # If the resource was previously loaded from the server, we will
     # try to update the record. Otherwise if it's a new record, then

--- a/test/unit/validation_test.rb
+++ b/test/unit/validation_test.rb
@@ -6,18 +6,35 @@ class ValidationTest < Minitest::Test
     property :name
     property :email_address
 
-    validates :name, presence: true
-    validates :email_address, format: /.*@.*/
+    validates :name, presence: true, on: :create
+    validates :email_address, format: /.*@.*/, on: :update
   end
 
-  def test_can_add_client_side_validations
-
+  def test_create_context_validation
     office = Office.new
-    assert_equal false, office.save
-
+    office.valid?
     assert office.errors[:name].present?
-    assert office.errors[:email_address].present?
-
   end
 
+  def test_create_context_validation_on_update
+    office = Office.new
+    office.id = "123"
+    office.mark_as_persisted!
+    office.valid?
+    assert office.errors[:name].blank?
+  end
+
+  def test_update_context_validation
+    office = Office.new(email_address: "123")
+    office.id = "123"
+    office.mark_as_persisted!
+    office.valid?
+    assert office.errors[:email_address].present?
+  end
+
+  def test_update_context_validation_on_create
+    office = Office.new(email_address: "123")
+    office.valid?
+    assert office.errors[:email_address].blank?
+  end
 end


### PR DESCRIPTION
By settings attributes via method_missing (instead of set_attribute) we can define custom setters in the resource classes and not have those fields hit the server.

```ruby
class Person < JsonApiClient::Resource
  attr_accessor :my_field
  # ...
end

person = Person.new(name: "Ben", my_field: "Blah")
person.save # => my_field is not passed to the server
```

Also, adding support for validation contexts: `on: :create` and `on: :update`.

```ruby
class Person < JsonApiClient::Resource
  validates :first_name, presence: true, on: :create
end
```

