### PR TITLE
Handle 401 Not Authorized Response

### DIFF
--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -13,6 +13,9 @@ module JsonApiClient
     class AccessDenied < ClientError
     end
 
+    class NotAuthorized < ClientError
+    end
+
     class ConnectionError < ApiError
     end
 

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -7,8 +7,7 @@ module JsonApiClient
 
           # look for meta[:status]
           if env[:body].is_a?(Hash)
-            code = env[:status]
-            #code = env[:body].fetch("meta", {}).fetch("status", 200).to_i
+            code = env[:body].fetch("meta", {}).fetch("status", 200).to_i
             handle_status(code, env)
           end
         end

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -7,7 +7,8 @@ module JsonApiClient
 
           # look for meta[:status]
           if env[:body].is_a?(Hash)
-            code = env[:body].fetch("meta", {}).fetch("status", 200).to_i
+            code = env[:status]
+            #code = env[:body].fetch("meta", {}).fetch("status", 200).to_i
             handle_status(code, env)
           end
         end
@@ -20,6 +21,8 @@ module JsonApiClient
       def handle_status(code, env)
         case code
         when 200..399
+        when 401
+          raise Errors::NotAuthorized, env
         when 403
           raise Errors::AccessDenied, env
         when 404

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -47,6 +47,15 @@ class ErrorsTest < MiniTest::Test
     end
   end
 
+  def test_access_denied
+    stub_request(:get, "http://example.com/users")
+      .to_return(headers: {content_type: "text/plain"}, status: 401, body: "not authorized")
+
+    assert_raises JsonApiClient::Errors::NotAuthorized do
+      User.all
+    end
+  end
+
   def test_errors_are_rescuable_by_default_rescue
     begin
       raise JsonApiClient::Errors::ApiError, "Something bad happened"


### PR DESCRIPTION
This was mentioned in #135. This PR provides support for surfacing the fact that the server returned a 401.