### PR TITLE
Added a config file and support for dasherized/camelized urls and attribute keys

### DIFF
--- a/lib/json_api_client.rb
+++ b/lib/json_api_client.rb
@@ -2,6 +2,7 @@ require 'faraday'
 require 'faraday_middleware'
 require 'json'
 require "addressable/uri"
+require 'json_api_client/configuration'
 
 module JsonApiClient
   autoload :Associations, 'json_api_client/associations'

--- a/lib/json_api_client/configuration.rb
+++ b/lib/json_api_client/configuration.rb
@@ -1,0 +1,41 @@
+# Based on jsonapi_resources configuration.rb file
+
+require 'json_api_client/formatter'
+
+module JsonApiClient
+  class Configuration
+    attr_reader :json_key_format,
+                :key_formatter,
+                :route_format,
+                :route_formatter
+
+    def initialize
+      #:underscored_key, :camelized_key, :dasherized_key, or custom
+      self.json_key_format = :underscored_key
+
+      #:underscored_route, :camelized_route, :dasherized_route, or custom
+      self.route_format = :underscored_route
+    end
+
+    def json_key_format=(format)
+      @json_key_format = format
+      @key_formatter = JsonApiClient::Formatter.formatter_for(format)
+    end
+
+    def route_format=(format)
+      @route_format = format
+      @route_formatter = JsonApiClient::Formatter.formatter_for(format)
+    end
+
+  end
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  @configuration ||= Configuration.new
+
+  def self.configure
+    yield(@configuration)
+  end
+end

--- a/lib/json_api_client/formatter.rb
+++ b/lib/json_api_client/formatter.rb
@@ -1,0 +1,137 @@
+# Taken form jsonapi_resources formatter
+
+require 'active_support/inflector'
+
+module JsonApiClient
+  class Formatter
+    class << self
+      def format(arg)
+        arg.to_s
+      end
+
+      def unformat(arg)
+         # We call to_s() here so that unformat consistently returns a string
+         # (instead of a symbol) regardless which Formatter subclass it is called on
+        arg.to_s
+      end
+
+      def formatter_for(format)
+        formatter_class_name = "JsonApiClient::#{format.to_s.camelize}Formatter"
+        formatter_class_name.safe_constantize
+      end
+    end
+  end
+
+  class KeyFormatter < Formatter
+    class << self
+      def format(key)
+        super
+      end
+
+      def unformat(formatted_key)
+        super
+      end
+    end
+  end
+
+  class RouteFormatter < Formatter
+    class << self
+      def format(route)
+        super
+      end
+
+      def unformat(formatted_route)
+        super
+      end
+    end
+  end
+
+  class ValueFormatter < Formatter
+    class << self
+      def format(raw_value)
+        super(raw_value)
+      end
+
+      def unformat(value)
+        super(value)
+      end
+
+      def value_formatter_for(type)
+        formatter_name = "#{type.to_s.camelize}Value"
+        formatter_for(formatter_name)
+      end
+    end
+  end
+
+  class UnderscoredKeyFormatter < KeyFormatter
+  end
+
+  class CamelizedKeyFormatter < KeyFormatter
+    class << self
+      def format(key)
+        super.camelize(:lower)
+      end
+
+      def unformat(formatted_key)
+        formatted_key.to_s.underscore
+      end
+    end
+  end
+
+  class DasherizedKeyFormatter < KeyFormatter
+    class << self
+      def format(key)
+        super.dasherize
+      end
+
+      def unformat(formatted_key)
+        formatted_key.to_s.underscore
+      end
+    end
+  end
+
+  class DefaultValueFormatter < ValueFormatter
+    class << self
+      def format(raw_value)
+        raw_value
+      end
+    end
+  end
+
+  class IdValueFormatter < ValueFormatter
+    class << self
+      def format(raw_value)
+        return if raw_value.nil?
+        raw_value.to_s
+      end
+    end
+  end
+
+  class UnderscoredRouteFormatter < RouteFormatter
+  end
+
+  class CamelizedRouteFormatter < RouteFormatter
+    class << self
+      def format(route)
+        super.camelize(:lower)
+      end
+
+      def unformat(formatted_route)
+        formatted_route.to_s.underscore
+      end
+    end
+  end
+
+  class DasherizedRouteFormatter < RouteFormatter
+    class << self
+      def format(route)
+        super.dasherize
+      end
+
+      def unformat(formatted_route)
+        formatted_route.to_s.underscore
+      end
+    end
+  end
+
+end

--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -38,7 +38,9 @@ module JsonApiClient
       protected
 
       def method_missing(method, *args, &block)
-        if method.to_s =~ /^(.*)=$/
+        normalized_method = JsonApiClient.configuration.key_formatter.unformat(method.to_s)
+
+        if normalized_method =~ /^(.*)=$/
           set_attribute($1, args.first)
         elsif has_attribute?(method)
           attributes[method]

--- a/lib/json_api_client/included_data.rb
+++ b/lib/json_api_client/included_data.rb
@@ -6,7 +6,7 @@ module JsonApiClient
       record_class = result_set.record_class
       grouped_data = data.group_by{|datum| datum["type"]}
       @data = grouped_data.inject({}) do |h, (type, records)|
-        klass = Utils.compute_type(record_class, type.singularize.classify)
+        klass = Utils.compute_type(record_class, JsonApiClient.configuration.key_formatter.unformat(type).singularize.classify)
         h[type] = records.map do |datum|
           params = klass.parser.parameters_from_resource(datum)
           resource = klass.load(params)

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -140,7 +140,7 @@ module JsonApiClient
               parse_related_links(*v)
             end
           else
-            table
+            JsonApiClient.configuration.key_formatter.format(table)
           end
         end.flatten
       end

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -54,7 +54,7 @@ module JsonApiClient
       #
       # @return [String] The table name for this resource
       def table_name
-        resource_name.pluralize
+        JsonApiClient.configuration.route_formatter.format(resource_name.pluralize)
       end
 
       # The name of a single resource. i.e. Article -> article, Person -> person
@@ -435,7 +435,9 @@ module JsonApiClient
     end
 
     def association_for(name)
-      self.class.associations.detect{|association| association.attr_name == name}
+      self.class.associations.detect do |association|
+        association.attr_name.to_s == JsonApiClient.configuration.key_formatter.unformat(name)
+      end
     end
 
     def attributes_for_serialization

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,3 +33,19 @@ end
 class UserPreference < TestResource
   self.primary_key = :user_id
 end
+
+def with_altered_config(changes)
+  # remember and overwrite config
+  old_config_values = {}
+  changes.each_pair do |key, value|
+    old_config_values[key] = JsonApiClient.configuration.send(key)
+    JsonApiClient.configuration.send("#{key}=", value)
+  end
+
+  yield
+
+  # restore config
+  old_config_values.each_pair do |key, value|
+    JsonApiClient.configuration.send("#{key}=", old_config_values[key])
+  end
+end

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -13,6 +13,14 @@ class Specified < TestResource
   has_many :bars, class_name: "Owner"
 end
 
+class PrefixedOwner < TestResource
+  has_many :prefixed_properties
+end
+
+class PrefixedProperty < TestResource
+  has_one :prefixed_owner
+end
+
 module Namespaced
   class Owner < TestResource
     has_many :properties
@@ -252,6 +260,128 @@ class AssociationTest < MiniTest::Test
     assert_equal(2, jeff.properties.length)
     assert_equal(Property, jeff.properties.first.class)
     assert_equal("123 Main St.", jeff.properties.first.address)
+  end
+
+  def test_load_has_many_with_multiword_resource_name
+    stub_request(:get, "http://example.com/prefixed_owners")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [
+          {
+            id: 1,
+            attributes: {
+              name: "Jeff Ching",
+            },
+            relationships: {
+              properties: {
+                data: [
+                  {id: 1, type: 'prefixed_property'},
+                  {id: 2, type: 'prefixed_property'}
+                ]
+              }
+            }
+          },
+          {id: 2, attributes: {name: "Barry Bonds"}},
+          {
+            id: 3,
+            attributes: {
+              name: "Hank Aaron"
+            },
+            relationships: {
+              properties: {
+                data: [
+                  {id: 3, type: 'prefixed_property'}
+                ]
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            id: 1,
+            type: 'prefixed_property',
+            attributes: {address: "123 Main St."}
+          },
+          {
+            id: 2,
+            type: 'prefixed_property',
+            attributes: {address: "223 Elm St."}
+          },
+          {
+            id: 3,
+            type: 'prefixed_property',
+            attributes: {address: "314 150th Ave"}
+          }
+        ]
+      }.to_json)
+    owners = PrefixedOwner.all
+    jeff = owners[0]
+    assert_equal("Jeff Ching", jeff.name)
+    assert_equal(2, jeff.properties.length)
+    assert_equal(PrefixedProperty, jeff.properties.first.class)
+    assert_equal("123 Main St.", jeff.properties.first.address)
+  end
+
+  def test_load_has_many_with_configurable_multiword_resource_name_and_type
+    with_altered_config(:json_key_format => :camelized_key,
+      :route_format => :dasherized_route) do
+
+      stub_request(:get, "http://example.com/prefixed-owners")
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+          data: [
+            {
+              id: 1,
+              attributes: {
+                name: "Jeff Ching",
+              },
+              relationships: {
+                properties: {
+                  data: [
+                    {id: 1, type: 'prefixed-property'},
+                    {id: 2, type: 'prefixed-property'}
+                  ]
+                }
+              }
+            },
+            {id: 2, attributes: {name: "Barry Bonds"}},
+            {
+              id: 3,
+              attributes: {
+                name: "Hank Aaron"
+              },
+              relationships: {
+                properties: {
+                  data: [
+                    {id: 3, type: 'prefixed-property'}
+                  ]
+                }
+              }
+            }
+          ],
+          included: [
+            {
+              id: 1,
+              type: 'prefixed-property',
+              attributes: {address: "123 Main St."}
+            },
+            {
+              id: 2,
+              type: 'prefixed-property',
+              attributes: {address: "223 Elm St."}
+            },
+            {
+              id: 3,
+              type: 'prefixed-property',
+              attributes: {address: "314 150th Ave"}
+            }
+          ]
+        }.to_json)
+      owners = PrefixedOwner.all
+      jeff = owners[0]
+      assert_equal("Jeff Ching", jeff.name)
+      assert_equal(2, jeff.properties.length)
+      assert_equal(PrefixedProperty, jeff.properties.first.class)
+      assert_equal("123 Main St.", jeff.properties.first.address)
+    end
   end
 
   def test_load_has_many_single_entry

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -58,11 +58,29 @@ class ResourceTest < MiniTest::Test
   end
 
   def test_dasherized_keys_support
-    article = Article.new("foo-bar" => "baz")
-    assert_equal("baz", article.send("foo-bar"))
-    assert_equal("baz", article.send(:"foo-bar"))
-    assert_equal("baz", article["foo-bar"])
-    assert_equal("baz", article[:"foo-bar"])
+    with_altered_config(:json_key_format => :dasherized_key) do
+      article = Article.new("foo-bar" => "baz")
+      # Exposed dasherized attributes as first class ruby methods and attributes
+      assert_equal("baz", article.foo_bar)
+      assert_equal("baz", article["foo_bar"])
+    end
+
+    with_altered_config(:json_key_format => :camelized_key) do
+      article = Article.new("fooBar" => "baz")
+      # Exposed camelized attributes as first class ruby methods and attributes
+      assert_equal("baz", article.foo_bar)
+      assert_equal("baz", article["foo_bar"])
+    end
+
+    with_altered_config(:json_key_format => :underscored_key) do
+      article = Article.new("foo-bar" => "baz")
+      # Does not recognize dasherized attributes, fall back to hash syntax
+      refute article.respond_to? :foo_bar
+      assert_equal("baz", article.send("foo-bar"))
+      assert_equal("baz", article.send(:"foo-bar"))
+      assert_equal("baz", article["foo-bar"])
+      assert_equal("baz", article[:"foo-bar"])
+    end
   end
 
 end


### PR DESCRIPTION
This PR gives us the ability to configure how we want JsonApiClient to behave using a config files, which currently supports the setting of the format of the json attribute keys the and the url routes.

It also allows the correct handling of associations when dasherized or camelized routes are used. And it should also fixe #134 - the fetching of associations when using hyphens.

The supplied tests should help explain the behaviour.

@chingor13 Would you be interested in merging this to extend json_api_client's flexibility? No worries if not, I can set up a dedicated fork to manage this.
