### PR TITLE
Adds configuration for error classes

### DIFF
--- a/lib/json_api_client/connection.rb
+++ b/lib/json_api_client/connection.rb
@@ -5,11 +5,13 @@ module JsonApiClient
 
     def initialize(options = {})
       site = options.fetch(:site)
+      resource = options.fetch(:resource)
       @faraday = Faraday.new(site) do |builder|
         builder.request :url_encoded
         builder.use Middleware::JsonRequest
         builder.use Middleware::Status
         builder.use Middleware::ParseJson
+        builder.use Middleware::InsertResource, resource
         builder.adapter Faraday.default_adapter
       end
       yield(self) if block_given?
@@ -27,7 +29,10 @@ module JsonApiClient
     end
 
     def execute(query)
-      faraday.send(query.request_method, query.path, query.params, query.headers)
+      faraday.send(query.request_method,
+                   query.path,
+                   query.params,
+                   query.headers)
     end
 
   end

--- a/lib/json_api_client/helpers/queryable.rb
+++ b/lib/json_api_client/helpers/queryable.rb
@@ -25,7 +25,7 @@ module JsonApiClient
 
         def build_connection
           return connection_object unless connection_object.nil?
-          self.connection_object = connection_class.new(connection_options.merge(site: site)).tap do |conn|
+          self.connection_object = connection_class.new(connection_options.merge(resource: self, site: site)).tap do |conn|
             yield(conn) if block_given?
           end
         end

--- a/lib/json_api_client/middleware.rb
+++ b/lib/json_api_client/middleware.rb
@@ -3,5 +3,6 @@ module JsonApiClient
     autoload :JsonRequest, 'json_api_client/middleware/json_request'
     autoload :ParseJson, 'json_api_client/middleware/parse_json'
     autoload :Status, 'json_api_client/middleware/status'
+    autoload :InsertResource, 'json_api_client/middleware/insert_resource'
   end
 end

--- a/lib/json_api_client/middleware/insert_resource.rb
+++ b/lib/json_api_client/middleware/insert_resource.rb
@@ -1,0 +1,17 @@
+module JsonApiClient
+  module Middleware
+    class InsertResource < Faraday::Middleware
+      attr_reader :resource
+
+      def initialize(app, resource)
+        @app = app
+        @resource = resource
+      end
+
+      def call(environment)
+        environment[:resource] = resource
+        @app.call(environment)
+      end
+    end
+  end
+end

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -18,9 +18,11 @@ module JsonApiClient
       def handle_status(code, env)
         case code
         when 404
-          raise Errors::NotFound, env[:url]
+          error_class = env[:resource].not_found_class
+          raise error_class, env[:url]
         when 500..599
-          raise Errors::ServerError, env[:url]
+          error_class = env[:resource].server_error_class
+          raise error_class, env[:url]
         end
       end
     end

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -8,11 +8,19 @@ require 'active_support/core_ext/enumerable'
 
 module JsonApiClient
   class Resource
-    class_attribute :site, :primary_key, :link_style, :default_headers
+    class_attribute :site,
+      :primary_key,
+      :link_style,
+      :default_headers,
+      :server_error_class,
+      :not_found_class
 
     self.primary_key = :id
     self.link_style = :id # or :url
     self.default_headers = {}
+
+    self.server_error_class = JsonApiClient::Errors::ServerError
+    self.not_found_class = JsonApiClient::Errors::NotFound
 
     class << self
       # base URL for this resource


### PR DESCRIPTION
Adds `JsonApiClient::Resource.server_error_class` and
`JsonApiClient::Resource.not_found_class` so the client can overwrite with
custom error classes. The primary benefit is so different services can
have separate errors and get handled and reported separately.