### PR TITLE
pass rebuild flag to _build_connection fixes #151

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -78,7 +78,7 @@ module JsonApiClient
       #
       # @return [Connection] The connection to the json api server
       def connection(rebuild = false, &block)
-        _build_connection(&block)
+        _build_connection(rebuild, &block)
         connection_object
       end
 


### PR DESCRIPTION
This correctly passes the rebuild flag from the connection method to the _build_connection method.