### PR TITLE
Allow linked resources to have links

### DIFF
--- a/lib/json_api_client/linked_data.rb
+++ b/lib/json_api_client/linked_data.rb
@@ -17,6 +17,12 @@ module JsonApiClient
         klass = klass_for(type)
         add_data(type, results.map{|result| klass.new(result)})
       end
+
+      @results_by_type_by_id.values.each do |results|
+        results.values.each do |result|
+          result.linked_data = self
+        end
+      end
     end
 
     def data_for(type, ids)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,9 @@ end
 class Address < TestResource
 end
 
+class State < TestResource
+end
+
 # for testing primary key option
 class UserPreference < TestResource
   self.primary_key = :user_id

--- a/test/unit/links_test.rb
+++ b/test/unit/links_test.rb
@@ -80,7 +80,7 @@ class LinksTest < MiniTest::Unit::TestCase
             {
               id: 4, address: "1st Ave S", state_id: 1,
               links: {
-                "state": 1
+                state: 1
               }
             }
           ],

--- a/test/unit/links_test.rb
+++ b/test/unit/links_test.rb
@@ -69,15 +69,27 @@ class LinksTest < MiniTest::Unit::TestCase
           "user.address" => {
             href: 'http://localhost:3000/api/1/addresses/{user.address}',
             type: "addresses"
+          },
+          "address.state" => {
+            href: 'http://localhost:3000/api/1/states/{address.state}',
+            type: "states"
           }
         },
         linked: {
           addresses: [
-            {id: 4, address: "1st Ave S"}
+            {
+              id: 4, address: "1st Ave S", state_id: 1,
+              links: {
+                "state": 1
+              }
+            }
           ],
           posts: [
             {id: 2, title: "Yo", body: "Lo"},
             {id: 3, title: "Foo", body: "Bar"}
+          ],
+          states: [
+            {id: 1, name: "Washington"}
           ]
         }
       }.to_json)
@@ -97,6 +109,10 @@ class LinksTest < MiniTest::Unit::TestCase
     assert_equal 1, address.length
     assert address.first.is_a?(Address), "should figure out what type of object for Address"
 
+    assert address.first.respond_to?(:state), "expected deep-linked state to be available"
+    state = address.first.state.first
+    assert state.is_a?(State), "should figure out what type of object for State"
+    assert_equal "Washington", state.name, "should load data from linked section for state"
   end
 
 end


### PR DESCRIPTION
So if a linked resource has its own links, you can access those. So if users have addresses, and addresses have states, and addresses and states are linked, it works. See tests.