### PR TITLE
Update bundler before in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+before_install:
+  - gem update bundler
 env:
   global:
     - CODECLIMATE_REPO_TOKEN=396d4263adb6febf1e6e9b0c0e176fbde35e1a116a3c1ecf8dd4f9384e41979b


### PR DESCRIPTION
Builds are broken because the `bundler` version that Travis CI
automatically uses at this time (`1.7.6`) is coming across an
error that was fixed in a later version/release.

Having an outdated version of `bundler` in the Travis CI builds is an
ongoing issue and this is currently the easiest work-around.

See:

* bundler/bundler#3558
* travis-ci/travis-ci#3531

Fix stolen from thoughtbot/factory_girl#846