### PR TITLE
Add update method as alias to update_attributes

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -280,6 +280,14 @@ module JsonApiClient
       save
     end
 
+    # Alias to update_attributes
+    #
+    # @param attrs [Hash] Attributes to update
+    # @return [Boolean] Whether the update succeeded or not
+    def update(attrs = {})
+      update_attributes(attrs)
+    end
+
     # Mark the record as persisted
     def mark_as_persisted!
       @persisted = true

--- a/test/unit/updating_test.rb
+++ b/test/unit/updating_test.rb
@@ -137,6 +137,38 @@ class UpdatingTest < MiniTest::Test
     })
   end
 
+  def test_can_update_found_record_in_builk_using_update_method
+    articles = Article.find(1)
+    article = articles.first
+
+    stub_request(:patch, "http://example.com/articles/1")
+      .with(headers: {content_type: "application/vnd.api+json", accept: "application/vnd.api+json"}, body: {
+          data: {
+            id: "1",
+            type: "articles",
+            attributes: {
+              title: "Modified title",
+              foo: "bar"
+            }
+          }
+        }.to_json)
+      .to_return(headers: {status: 200, content_type: "application/vnd.api+json"}, body: {
+        data: {
+          id: "1",
+          type: "articles",
+          attirbutes: {
+            title: "Modified title",
+            foo: "bar"
+          }
+        }
+      }.to_json)
+
+    assert article.update({
+      title: "Modified title",
+      foo: "bar"
+    })
+  end
+
   def test_can_update_single_relationship
     articles = Article.find(1)
     article = articles.first


### PR DESCRIPTION
Since Rails 4, the update_attributes becomes an [alias of the update method](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-update_attributes).

This PR implements the `update` method, to reflect the same ActiveRecord API.