### PR TITLE
Add ability to append any params to the request

### DIFF
--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -9,6 +9,7 @@ module JsonApiClient
         @primary_key = nil
         @pagination_params = {}
         @path_params = {}
+        @additional_params = {}
         @filters = {}
         @includes = []
         @orders = []
@@ -54,6 +55,11 @@ module JsonApiClient
         self
       end
 
+      def with_params(more_params)
+        @additional_params = more_params
+        self
+      end
+
       def first
         paginate(page: 1, per_page: 1).to_a.first
       end
@@ -70,6 +76,7 @@ module JsonApiClient
           .merge(select_params)
           .merge(primary_key_params)
           .merge(path_params)
+          .merge(additional_params)
       end
 
       def to_a
@@ -96,6 +103,10 @@ module JsonApiClient
 
       def path_params
         @path_params.empty? ? {} : {path: @path_params}
+      end
+
+      def additional_params
+        @additional_params
       end
 
       def primary_key_params

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -56,7 +56,7 @@ module JsonApiClient
       end
 
       def with_params(more_params)
-        @additional_params = more_params
+        @additional_params.merge!(more_params)
         self
       end
 

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -48,7 +48,7 @@ module JsonApiClient
 
     class << self
       extend Forwardable
-      def_delegators :_new_scope, :where, :order, :includes, :select, :all, :paginate, :page, :first, :find
+      def_delegators :_new_scope, :where, :order, :includes, :select, :all, :paginate, :page, :with_params, :first, :find
 
       # The table name for this resource. i.e. Article -> articles, Person -> people
       #

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -86,6 +86,16 @@ class QueryBuilderTest < MiniTest::Test
     articles = Article.order(foo: :desc).order(:bar).to_a
   end
 
+  def test_can_specify_additional_params
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {sort: "foo"})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+
+    articles = Article.with_params(sort: "foo").to_a
+  end
+
   def test_can_select_fields
     stub_request(:get, "http://example.com/articles")
       .with(query: {fields: {articles: 'title,body'}})


### PR DESCRIPTION
This is incredibly useful for us. Our use case is as follows:
Hitting our Fields (Paddocks) Api with this:
```ruby
UserApi::Field.find(123)
```
(with some other transformation I've removed) yields this:
```
GET "/user_api/v1/fields/123"
```
which returns data attributes for that field (paddock).

Although, if we want paddock data attributes for a specific season of farming, e.g. 2015, then with this change, we can now run:
```ruby
UserApi::Field.with_params(season_id: 456).find(123)
```
which yields this:
```
GET "/user_api/v1/fields/123?&season_id=456"
```
which will return us attributes for paddock 123 that are specific to season 456.

`.with_params` can be appended at any point to any scope e.g. `find` or `all` etc.
Thanks for reading.