### PR TITLE
Up the faraday gem requirement to ~> 0.9

### DIFF
--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'Build client libraries compliant with specification defined by jsonapi.org'
 
   s.add_dependency "activesupport", '>= 3.2.0'
-  s.add_dependency "faraday", '>= 0.8.0'
+  s.add_dependency "faraday", '~> 0.9'
   s.add_dependency "faraday_middleware", '~> 0.9'
   s.add_dependency "addressable", '~> 2.2'
   s.add_dependency "activemodel", '>= 3.2.0'


### PR DESCRIPTION
We're referencing error classes only available in 0.9+
The faraday_middleware_requirement should be fine

This fixes #157 