### PR TITLE
Correctly respect null data being returned when requesting sideloaded resources

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -410,8 +410,9 @@ module JsonApiClient
       return nil unless relationship_definitions = relationships[method]
 
       # look in included data
-      data = last_result_set.included.data_for(method, relationship_definitions)
-      return data if data
+      if relationship_definitions.key?("data")
+        return last_result_set.included.data_for(method, relationship_definitions)
+      end
 
       if association = association_for(method)
         # look for a defined relationship url


### PR DESCRIPTION
Previously, when you wanted to sideload related data, if the sideloaded data was a `has_one` relationship and the related object didn't exist, a subsequent API call was made instead of returning `nil`.

Now, if the original request returns sideloaded relationships with a `data` value of `null` for a `has_one` relationship, no additional API call is made.

Conforms to the JSON API spec as defined at http://jsonapi.org/format/#fetching-relationships-responses-200.

This should also be a replacement of #121, with tests passing.