### PR TITLE
Fixes parsing of total pages count from resources last link.

### DIFF
--- a/lib/json_api_client/paginating/paginator.rb
+++ b/lib/json_api_client/paginating/paginator.rb
@@ -28,7 +28,7 @@ module JsonApiClient
         if links["last"]
           uri = result_set.links.link_url_for("last")
           last_params = params_for_uri(uri)
-          last_params.fetch("page") do
+          last_params.fetch("page[number]") do
             current_page
           end.to_i
         else


### PR DESCRIPTION
Fixes parsing of total pages count from resources last link. Should parse page[number] as in JSON API 1.0 specs