### PR TITLE
Select fields using strings or symbols, array or not

### DIFF
--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -33,8 +33,8 @@ module JsonApiClient
         self
       end
 
-      def select(fields)
-        @fields += fields.split(",").map(&:strip)
+      def select(*fields)
+        @fields += Array(fields).flatten.map(&:to_s).map { |i| i.split(",") }.flatten.map(&:strip)
         self
       end
 

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -105,4 +105,31 @@ class QueryBuilderTest < MiniTest::Test
     articles = Article.select("title,body").to_a
   end
 
+  def test_can_select_fields_using_array_of_strings
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {fields: {articles: 'title,body'}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    articles = Article.select(["title", "body"]).to_a
+  end
+
+  def test_can_select_fields_using_array_of_symbols
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {fields: {articles: 'title,body'}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    articles = Article.select([:title, :body]).to_a
+  end
+
+  def test_can_select_fields_using_implicit_array
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {fields: {articles: 'title,body'}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    articles = Article.select(:title, :body).to_a
+  end
+
 end


### PR DESCRIPTION
Hi! Thanks for this nice and useful gem.

I ran into a tiny inconvenience:

```ruby
Article.select("title,body").first
# all good
```

```ruby
Article.select(["title", "body"]).first
# error
```

So I thought people who are used to Ruby's flexibility could benefit from calling this method in various convenient ways:

```ruby
Article.select("title,body").first
Article.select(["title", "body"]).first
Article.select([:title, :body]).first
Article.select("title", "body").first
Article.select(:title, :body).first
```

(I personally enjoy the last one since ActiveRecord allows the same style, but to each their own.)

This PR brings a patch and a few tests, and if you think this small feature could be useful, I'm happy to refactor a bit with more explicit names, add a comment about the method params, and update the README.

Thanks!