### PR TITLE
Support method call to access for JSON API data

### DIFF
--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -11,7 +11,7 @@ module JsonApiClient
 
         return @attributes unless attrs.present?
         attrs.each do |key, value|
-          send("#{key}=", value)
+          set_attribute(key, value)
         end
       end
 
@@ -31,8 +31,8 @@ module JsonApiClient
         end
       end
 
-      def has_attribute?(attr_name)
-        attributes.has_key?(attr_name)
+      def has_attribute?(name)
+        attributes.has_key?(name) || attributes.has_key?(name.to_s.dasherize)
       end
 
       protected
@@ -41,14 +41,14 @@ module JsonApiClient
         if method.to_s =~ /^(.*)=$/
           set_attribute($1, args.first)
         elsif has_attribute?(method)
-          attributes[method]
+          read_attribute(method)
         else
           super
         end
       end
 
       def read_attribute(name)
-        attributes.fetch(name, nil)
+        attributes.fetch(name) { attributes.fetch(name.to_s.dasherize, nil) }
       end
 
       def set_attribute(name, value)

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -63,6 +63,7 @@ class ResourceTest < MiniTest::Test
     assert_equal("baz", article.send(:"foo-bar"))
     assert_equal("baz", article["foo-bar"])
     assert_equal("baz", article[:"foo-bar"])
+    assert_equal("baz", article.foo_bar)
   end
 
 end


### PR DESCRIPTION
JSON API specification recommends using `-` as separator between multiple words.

> Member names SHOULD contain only the characters “a-z” (U+0061 to
> U+007A), “0-9” (U+0030 to U+0039), and the hyphen minus (U+002D
> HYPHEN-MINUS, “-“) as separator between multiple words.

ref: http://jsonapi.org/recommendations/#naming

On the other hand, using underscore for multiple words in method is Ruby way.
So this commit allows that using Ruby way to access to data.