### PR TITLE
Consider subclass overriding

### DIFF
--- a/lib/json_api_client/paginating/paginator.rb
+++ b/lib/json_api_client/paginating/paginator.rb
@@ -40,7 +40,7 @@ module JsonApiClient
       def total_entries
         per_page * total_pages
       end
-      alias_method :total_count, :total_entries
+      def total_count; total_entries; end
 
       def offset
         per_page * (current_page - 1)

--- a/test/unit/custom_paginator_test.rb
+++ b/test/unit/custom_paginator_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class CustomPaginatorTest < MiniTest::Test
+
+  class CustomPaginator < JsonApiClient::Paginating::Paginator
+    def total_entries
+      42
+    end
+  end
+
+  class Book < JsonApiClient::Resource
+    self.site = "http://example.com/"
+    self.paginator = CustomPaginator
+  end
+
+  def test_can_override
+    stub_request(:get, "http://example.com/books")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+
+    books = Book.all
+    assert_equal 42, books.total_count
+    assert_equal 42, books.total_entries
+  end
+end


### PR DESCRIPTION
If we have following custom paginator:

```ruby
class CustomPaginator < JsonApiClient::Paginating::Paginator
  def total_entries
    42
  end
end
```

`CustomPaginator#total_count` will not return 42 because `alias_method` retains access
to old method (`JsonApiClient::Paginating::Paginator#total_count`).