### PR TITLE
Don't explode when parsing `{"data": null}`

### DIFF
--- a/lib/json_api_client/parsers/parser.rb
+++ b/lib/json_api_client/parsers/parser.rb
@@ -65,7 +65,7 @@ module JsonApiClient
 
           # we will treat everything as an Array
           results = [results] unless results.is_a?(Array)
-          resources = results.map do |res|
+          resources = results.compact.map do |res|
             resource = result_set.record_class.load(parameters_from_resource(res))
             resource.last_result_set = result_set
             resource

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ end
 
 class Article < TestResource
   has_many :comments
+  has_one :author
 end
 
 class Person < TestResource

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -23,4 +23,37 @@ class ParserTest < MiniTest::Test
     assert_equal "Rails is Omakase", article.title
   end
 
+  def test_can_parse_null_data
+    # Per http://jsonapi.org/format/#fetching-resources, it is sometimes
+    # appropriate for an API to respond with a 200 status and null data
+    # when the requested URL is one that might correspond to a single
+    # resource, but doesn’t currently
+
+    stub_request(:get, "http://example.com/articles/1")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: {
+          type: "articles",
+          id: "1",
+          attributes: { title: "Rails is Omakase" },
+          relationships: {
+            author: {
+              links: {
+                related: "http://example.com/articles/1/author"
+              }
+            }
+          }
+        }
+      }.to_json)
+
+    stub_request(:get, "http://example.com/articles/1/author")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: nil
+      }.to_json)
+
+    article = Article.find(1).first
+    author = article.author
+
+    assert_equal nil, author
+  end
+
 end


### PR DESCRIPTION
Per http://jsonapi.org/format/#fetching-resources, it is sometimes appropriate for an API to respond with a 200 status and null data when the requested URL is one that might correspond to a single resource, but doesn’t currently.

Previous to this change, attempting to parse such a response would throw `NoMethodError: undefined method 'slice' for nil:NilClass` as it tried to extract params from `nil`