### PR TITLE
Support a query-based links href

### DIFF
--- a/lib/json_api_client/linked_data.rb
+++ b/lib/json_api_client/linked_data.rb
@@ -53,9 +53,9 @@ module JsonApiClient
 
     # make an api request to fetch the missing data
     def fetch_data(klass, type, missing_ids)
-      path = URI(link_definition.url_for(type, missing_ids)).path
+      uri = URI(link_definition.url_for(type, missing_ids)).to_s
 
-      query = Query::Linked.new(path)
+      query = Query::Linked.new(uri)
       results = klass.run_request(query)
 
       key = link_definition.attribute_name_for(type).to_s

--- a/test/unit/links_test.rb
+++ b/test/unit/links_test.rb
@@ -13,7 +13,7 @@ class LinksTest < MiniTest::Unit::TestCase
         ],
         links: {
           "user.posts" => {
-            href: 'http://localhost:3000/api/1/posts/{user.posts}',
+            href: 'http://localhost:3000/api/1/posts?ids={user.posts}',
             type: "posts"
           },
           "user.address" => {
@@ -22,7 +22,7 @@ class LinksTest < MiniTest::Unit::TestCase
           }
         }
       }.to_json)
-    stub_request(:get, "http://localhost:3000/api/1/posts/2,3.json")
+    stub_request(:get, "http://localhost:3000/api/1/posts.json?ids=2,3")
       .to_return(headers: {content_type: "application/json"}, body: {
         posts: [
           {id: 2, title: "Yo", body: "Lo"},


### PR DESCRIPTION
For looking up many records at once some APIs use a query parameter
instead of an endpoint.