### PR TITLE
Don't attempt param substitution for blank `_prefix_path`

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -109,7 +109,7 @@ module JsonApiClient
       # Return the path or path pattern for this resource
       def path(params = nil)
         parts = [resource_path]
-        if params
+        if params && _prefix_path.present?
           path_params = params.delete(:path) || params
           parts.unshift(_prefix_path % path_params.symbolize_keys)
         else


### PR DESCRIPTION
Fixes `warning: too many arguments for format string` during test runs