### PR TITLE
Initialize Resource's @persisted to nil

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -274,6 +274,7 @@ module JsonApiClient
     #
     # @param params [Hash] Attributes, links, and relationships
     def initialize(params = {})
+      @persisted = nil
       self.links = self.class.linker.new(params.delete("links") || {})
       self.relationships = self.class.relationship_linker.new(params.delete("relationships") || {})
       self.class.associations.each do |association|


### PR DESCRIPTION
Fixes `warning: instance variable @persisted not initialized` warnings during test runs (and presumably at runtime).