### PR TITLE
Cleanup remaining test warnings

### DIFF
--- a/lib/json_api_client/connection.rb
+++ b/lib/json_api_client/connection.rb
@@ -12,7 +12,7 @@ module JsonApiClient
         builder.use Middleware::JsonRequest
         builder.use Middleware::Status
         builder.use Middleware::ParseJson
-        builder.adapter *adapter_options
+        builder.adapter(*adapter_options)
       end
       yield(self) if block_given?
     end

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -2,7 +2,7 @@ module JsonApiClient
   module Query
     class Builder
 
-      attr_reader :klass, :path_params
+      attr_reader :klass
       delegate :key_formatter, to: :klass
 
       def initialize(klass)

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -518,7 +518,7 @@ class AssociationTest < MiniTest::Test
         ]
       }.to_json)
 
-    specified = Specified.create({
+    Specified.create({
       :id => 12,
       :foo_id => 10,
       :name => "Blah"
@@ -557,7 +557,7 @@ class AssociationTest < MiniTest::Test
         }
       }.to_json)
 
-    specified = Specified.create(foo_id: 1)
+    Specified.create(foo_id: 1)
   end
 
 end

--- a/test/unit/compound_document_test.rb
+++ b/test/unit/compound_document_test.rb
@@ -126,12 +126,12 @@ class CompoundDocumentTest < MiniTest::Test
     assert comments.all?{|comment| comment.is_a?(Comment)}, "expected this has-many relationship to return an array of Comment resources"
     assert_equal ["5", "12"], comments.map(&:id), "expected to return the comments in the order specified by the link"
 
-    comment = comments.last
-    assert_equal "I like XML better", comment.body
-    assert_equal "12", comment.id
-    assert_equal "http://example.com/comments/12", comment.links.self
+    last_comment = comments.last
+    assert_equal "I like XML better", last_comment.body
+    assert_equal "12", last_comment.id
+    assert_equal "http://example.com/comments/12", last_comment.links.self
 
-    nested_comments = comment.comments
+    nested_comments = last_comment.comments
     assert comments.is_a?(Array), "expected this has-many relationship to return an array"
     assert comments.all?{|comment| comment.is_a?(Comment)}, "expected this has-many relationship to return an array of Comment resources"
 

--- a/test/unit/custom_header_test.rb
+++ b/test/unit/custom_header_test.rb
@@ -19,7 +19,7 @@ class CustomHeaderTest < MiniTest::Test
       }.to_json)
 
     CustomHeaderResource.with_headers(x_my_header: "asdf") do
-      resources = CustomHeaderResource.find(1)
+      CustomHeaderResource.find(1)
     end
   end
 
@@ -37,7 +37,7 @@ class CustomHeaderTest < MiniTest::Test
       }.to_json)
 
     CustomHeaderResource.with_headers(x_my_header: "asdf") do
-      resources = CustomHeaderResource.create(foo: "bar")
+      CustomHeaderResource.create(foo: "bar")
     end
   end
 
@@ -67,7 +67,7 @@ class CustomHeaderTest < MiniTest::Test
       threads << Thread.new do
         CustomHeaderResource.with_headers(x_my_header: "Header #{i}") do
           wait_for { @ready }
-          resources = CustomHeaderResource.find(i)
+          CustomHeaderResource.find(i)
         end
       end
     end

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -56,7 +56,7 @@ class ErrorsTest < MiniTest::Test
     end
   end
 
-  def test_access_denied
+  def test_not_authorized
     stub_request(:get, "http://example.com/users")
       .to_return(headers: {content_type: "text/plain"}, status: 401, body: "not authorized")
 

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -8,7 +8,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.where(author: '5').to_a
+    Article.where(author: '5').to_a
   end
 
   def test_can_specify_nested_includes
@@ -17,7 +17,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.includes(comments: :author).to_a
+    Article.includes(comments: :author).to_a
   end
 
   def test_can_specify_multiple_includes
@@ -26,7 +26,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.includes({comments: :author}, :tags).to_a
+    Article.includes({comments: :author}, :tags).to_a
   end
 
   def test_can_paginate
@@ -35,7 +35,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.paginate(page: 3, per_page: 6).to_a
+    Article.paginate(page: 3, per_page: 6).to_a
   end
 
   def test_can_sort_asc
@@ -45,7 +45,7 @@ class QueryBuilderTest < MiniTest::Test
         data: []
       }.to_json)
 
-    articles = Article.order(foo: :asc).to_a
+    Article.order(foo: :asc).to_a
   end
 
   def test_sort_defaults_to_asc
@@ -55,7 +55,7 @@ class QueryBuilderTest < MiniTest::Test
         data: []
       }.to_json)
 
-    articles = Article.order(:foo).to_a
+    Article.order(:foo).to_a
   end
 
   def test_can_sort_desc
@@ -65,7 +65,7 @@ class QueryBuilderTest < MiniTest::Test
         data: []
       }.to_json)
 
-    articles = Article.order(foo: :desc).to_a
+    Article.order(foo: :desc).to_a
   end
 
   def test_can_sort_multiple
@@ -74,7 +74,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.order(foo: :desc, bar: :asc).to_a
+    Article.order(foo: :desc, bar: :asc).to_a
   end
 
   def test_can_sort_mixed
@@ -83,7 +83,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.order(foo: :desc).order(:bar).to_a
+    Article.order(foo: :desc).order(:bar).to_a
   end
 
   def test_can_specify_additional_params
@@ -93,7 +93,7 @@ class QueryBuilderTest < MiniTest::Test
         data: []
       }.to_json)
 
-    articles = Article.with_params(sort: "foo").to_a
+    Article.with_params(sort: "foo").to_a
   end
 
   def test_can_select_fields
@@ -102,7 +102,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.select("title,body").to_a
+    Article.select("title,body").to_a
   end
 
   def test_can_select_fields_using_array_of_strings
@@ -111,7 +111,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.select(["title", "body"]).to_a
+    Article.select(["title", "body"]).to_a
   end
 
   def test_can_select_fields_using_array_of_symbols
@@ -120,7 +120,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.select([:title, :body]).to_a
+    Article.select([:title, :body]).to_a
   end
 
   def test_can_select_fields_using_implicit_array
@@ -129,7 +129,7 @@ class QueryBuilderTest < MiniTest::Test
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
-    articles = Article.select(:title, :body).to_a
+    Article.select(:title, :body).to_a
   end
 
 end

--- a/test/unit/schemable_test.rb
+++ b/test/unit/schemable_test.rb
@@ -117,7 +117,7 @@ class SchemableTest < MiniTest::Test
     end
   end
 
-  def test_boolean_casts_to_true
+  def test_boolean_casts_to_false
     ["0", 0, "false", false].each do |v|
       resource = SchemaResource.new
       resource.b = v

--- a/test/unit/status_test.rb
+++ b/test/unit/status_test.rb
@@ -12,7 +12,7 @@ class StatusTest < MiniTest::Test
       }.to_json)
 
     assert_raises JsonApiClient::Errors::ServerError do
-      users = User.find(1)
+      User.find(1)
     end
   end
 
@@ -25,7 +25,7 @@ class StatusTest < MiniTest::Test
       body: "something irrelevant")
 
     assert_raises JsonApiClient::Errors::ServerError do
-      users = User.find(1)
+      User.find(1)
     end
   end
 
@@ -38,7 +38,7 @@ class StatusTest < MiniTest::Test
       body: "something irrelevant")
 
     assert_raises JsonApiClient::Errors::NotFound do
-      users = User.find(1)
+      User.find(1)
     end
   end
 
@@ -52,7 +52,7 @@ class StatusTest < MiniTest::Test
       }.to_json)
 
     assert_raises JsonApiClient::Errors::NotFound do
-      users = User.find(1)
+      User.find(1)
     end
   end
 


### PR DESCRIPTION
Along with #198 and #199, this cleans up the remaining test warning and ensures all tests are being run.