### PR TITLE
Don't raise KeyError when trying to navigate to nil next_page

### DIFF
--- a/lib/json_api_client/linking/top_level_links.rb
+++ b/lib/json_api_client/linking/top_level_links.rb
@@ -31,6 +31,7 @@ module JsonApiClient
       end
 
       def fetch_link(link_name)
+        return unless respond_to_missing?(link_name)
         record_class.requestor.linked(link_url_for(link_name))
       end
     end


### PR DESCRIPTION
I'm having trouble looping through paginated resources because the last page doesn't have a `next` link, and instead of `resource.pages.next` returning `nil`, it raises a `KeyError`.

```ruby
resources = Api::Resource.paginated(per_page: 10)

while resources.present?
  resources.map do |resource|
    puts resouce.id
  end

  resources = begin
    resources.pages.next
  rescue KeyError
    nil
  end
end
```

This PR attempts to fix it, but there are many questions raised from investigating:

1. Is it the responsibility of the gem or the user to handle the last page? Users currently have to rescue a `KeyError` exception, which isn't explicitly related to a missing resource.
2. If the gem can make it easier for the user, should it return `nil`? `[]`? an empty `Resource` object?
3. What about the previous page on the very first page of a resource?

Or… am I iterating through pages the wrong way? Happy to complete this PR or add more documentation either way!

/cc @chingor13 @bvandenbos @sharshenov @reidab @dplummer 