### PR TITLE
Use key formatters for relationship names

### DIFF
--- a/lib/json_api_client/relationships/relations.rb
+++ b/lib/json_api_client/relationships/relations.rb
@@ -5,7 +5,11 @@ module JsonApiClient
       include Helpers::Dirty
       include ActiveModel::Serialization
 
-      def initialize(relations)
+      attr_reader :record_class
+      delegate :key_formatter, to: :record_class
+
+      def initialize(record_class, relations)
+        @record_class = record_class
         self.attributes = relations
         clear_changes_information
       end

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -292,7 +292,7 @@ module JsonApiClient
     def initialize(params = {})
       @persisted = nil
       self.links = self.class.linker.new(params.delete("links") || {})
-      self.relationships = self.class.relationship_linker.new(params.delete("relationships") || {})
+      self.relationships = self.class.relationship_linker.new(self.class, params.delete("relationships") || {})
       self.class.associations.each do |association|
         if params.has_key?(association.attr_name.to_s)
           set_attribute(association.attr_name, association.parse(params[association.attr_name.to_s]))

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -272,7 +272,7 @@ class AssociationTest < MiniTest::Test
               name: "Jeff Ching",
             },
             relationships: {
-              properties: {
+              prefixed_properties: {
                 data: [
                   {id: 1, type: 'prefixed_property'},
                   {id: 2, type: 'prefixed_property'}
@@ -287,7 +287,7 @@ class AssociationTest < MiniTest::Test
               name: "Hank Aaron"
             },
             relationships: {
-              properties: {
+              prefixed_properties: {
                 data: [
                   {id: 3, type: 'prefixed_property'}
                 ]
@@ -316,9 +316,9 @@ class AssociationTest < MiniTest::Test
     owners = PrefixedOwner.all
     jeff = owners[0]
     assert_equal("Jeff Ching", jeff.name)
-    assert_equal(2, jeff.properties.length)
-    assert_equal(PrefixedProperty, jeff.properties.first.class)
-    assert_equal("123 Main St.", jeff.properties.first.address)
+    assert_equal(2, jeff.prefixed_properties.length)
+    assert_equal(PrefixedProperty, jeff.prefixed_properties.first.class)
+    assert_equal("123 Main St.", jeff.prefixed_properties.first.address)
   end
 
   def test_load_has_many_with_configurable_multiword_resource_name_and_type
@@ -334,7 +334,7 @@ class AssociationTest < MiniTest::Test
                 name: "Jeff Ching",
               },
               relationships: {
-                properties: {
+                prefixedProperties: {
                   data: [
                     {id: 1, type: 'prefixed-property'},
                     {id: 2, type: 'prefixed-property'}
@@ -349,7 +349,7 @@ class AssociationTest < MiniTest::Test
                 name: "Hank Aaron"
               },
               relationships: {
-                properties: {
+                prefixedProperties: {
                   data: [
                     {id: 3, type: 'prefixed-property'}
                   ]
@@ -378,9 +378,9 @@ class AssociationTest < MiniTest::Test
       owners = PrefixedOwner.all
       jeff = owners[0]
       assert_equal("Jeff Ching", jeff.name)
-      assert_equal(2, jeff.properties.length)
-      assert_equal(PrefixedProperty, jeff.properties.first.class)
-      assert_equal("123 Main St.", jeff.properties.first.address)
+      assert_equal(2, jeff.prefixed_properties.length)
+      assert_equal(PrefixedProperty, jeff.prefixed_properties.first.class)
+      assert_equal("123 Main St.", jeff.prefixed_properties.first.address)
     end
   end
 


### PR DESCRIPTION
When I was cleaning up #201, I missed that the multi-word relationship tests weren't actually testing a multi-word relationship name. Even though `has_many :prefixed_properties` was declared, the actual relationship parsing was on a `properties` relation that was being dynamically discovered.

Updating this test revealed that multi-word relation names were broken, so here's the fix.