### PR TITLE
Require JsonApiClient::VERSION. Issue #206

### DIFF
--- a/lib/json_api_client.rb
+++ b/lib/json_api_client.rb
@@ -25,4 +25,5 @@ module JsonApiClient
   autoload :ResultSet, 'json_api_client/result_set'
   autoload :Schema, 'json_api_client/schema'
   autoload :Utils, 'json_api_client/utils'
+  autoload :VERSION, 'json_api_client/version'
 end


### PR DESCRIPTION
Fixes issue #206.
Requires VERSION in JsonApiClient base class.