### PR TITLE
Raise on a 422

### DIFF
--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -31,6 +31,12 @@ module JsonApiClient
       end
     end
 
+    class UnprocessableEntity < ServerError
+      def message
+        "Unable to process the request"
+      end
+    end
+
     class NotFound < ServerError
       attr_reader :uri
       def initialize(uri)

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -28,6 +28,8 @@ module JsonApiClient
           raise Errors::NotFound, env[:url]
         when 409
           raise Errors::Conflict, env
+        when 422
+          raise Errors::UnprocessableEntity, env
         when 400..499
           # some other error
         when 500..599

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -65,6 +65,15 @@ class ErrorsTest < MiniTest::Test
     end
   end
 
+  def test_unprocessable_entity
+    stub_request(:get, "http://example.com/users")
+      .to_return(status: 422, body: "something irrelevant")
+
+    assert_raises JsonApiClient::Errors::UnprocessableEntity do
+      User.all
+    end
+  end
+
   def test_errors_are_rescuable_by_default_rescue
     begin
       raise JsonApiClient::Errors::ApiError, "Something bad happened"


### PR DESCRIPTION
I often find myself returning a 422 when a request is valid, but cannot be carried out given the business logic. With this gem, I've been using a custom parser so that I can `raise` on a 422 and actually see the response body. I think it makes sense for the client to raise in such a situation as it generally cannot be remedied programmatically.