### PR TITLE
Allow custom exception status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,18 @@ module MyApi
 end
 ```
 
+### Specifying exception status codes
+
+The `JsonApiClient::Middleware::Status` middleware will raise an exception on the following status codes: 401, 403, 404, 409, and 500 to 599. You can specify additional status codes on top of this, and the middleware will raise a `JsonApiClient::Errors::ApiError` exception.
+
+```ruby
+# Raise on unprocessable entity
+JsonApiClient::Middleware::Status.raise_on(422)
+
+# Raise on multiple status codes
+JsonApiClient::Middleware::Status.raise_on(400, 422..499)
+```
+
 ### Custom Parser
 
 You can configure your API client to use a custom parser that implements the `parse` class method.  It should return a `JsonApiClient::ResultSet` instance. You can use it by setting the parser attribute on your model:

--- a/test/unit/status_test.rb
+++ b/test/unit/status_test.rb
@@ -56,4 +56,19 @@ class StatusTest < MiniTest::Test
     end
   end
 
+  def test_server_responding_with_custom_error_status
+    JsonApiClient::Middleware::Status.raise_on(400, 422..499)
+
+    stub_request(:get, "http://example.com/users/1")
+      .to_return(headers: {
+        content_type: "text/plain"
+      },
+      status: 422,
+      body: "something irrelevant")
+
+    assert_raises JsonApiClient::Errors::ApiError do
+      User.find(1)
+    end
+  end
+
 end


### PR DESCRIPTION
As a follow-up to this issue (https://github.com/chingor13/json_api_client/issues/219), this PR (https://github.com/chingor13/json_api_client/pull/212) was reverted to guarantee backwards compatibility.

This new PR is backwards compatible and allows someone using the gem to specify additional status codes which will raise an exception. One could add code like this in an initializer to achieve this:
```
JsonApiClient::Middleware::Status.raise_on(400, 422..499)
```