### PR TITLE
remove redundant checks for nil white type casting

### DIFF
--- a/lib/json_api_client/schema.rb
+++ b/lib/json_api_client/schema.rb
@@ -14,9 +14,9 @@ module JsonApiClient
         when :float
           value.to_f
         when :time
-          value.is_a?(Time) || nil ? value : Time.parse(value)
+          value.is_a?(Time) ? value : Time.parse(value.to_s)
         when :decimal
-          value.nil? ? nil : BigDecimal.new(value)
+          BigDecimal.new(value)
         when :boolean
           case value
           when "false", "0", 0, false


### PR DESCRIPTION
```
 return value if type.nil? 
```
is already performed, so no need to recheck for nil again