### PR TITLE
Fixes #237 Resource links missing on create

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -409,6 +409,7 @@ module JsonApiClient
         mark_as_persisted!
         if updated = last_result_set.first
           self.attributes = updated.attributes
+          self.links.attributes = updated.links.attributes
           self.relationships.attributes = updated.relationships.attributes
           clear_changes_information
         end

--- a/test/unit/creation_test.rb
+++ b/test/unit/creation_test.rb
@@ -35,6 +35,12 @@ class CreationTest < MiniTest::Test
           id: "1",
           attributes: {
               title: "Rails is Omakase"
+          },
+          links: {
+            self: "http://example.com/articles/1",
+            other: {
+              href: "http://example.com/other"
+            }
           }
         }
       }.to_json)
@@ -66,6 +72,16 @@ class CreationTest < MiniTest::Test
     assert article.save
     assert article.persisted?
     assert_equal "1", article.id
+  end
+
+  def test_can_create_with_links
+    article = Article.new({
+                              title: "Rails is Omakase"
+                          })
+
+    assert article.save
+    assert article.persisted?
+    assert_equal "http://example.com/articles/1", article.links.self
   end
 
   def test_can_create_with_new_record_with_relationships_and_save


### PR DESCRIPTION
This pull request fixes an issue (#237) whereby when a resource is created and the response from the server contains resource level links, these are not present in the created object's "links" object.

I have written a test which proved this was the case and the implementation now fixes the issue.