### PR TITLE
Make paginator paging params configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,17 @@ end
 
 You can customize how your resources find pagination information from the response.
 
+If the [existing paginator](https://github.com/chingor13/json_api_client/blob/master/lib/json_api_client/paginating/paginator.rb) fits your requirements but you don't use the default `page` and `per_page` params for pagination, you can customise the param keys as follows:
+
+```ruby
+JsonApiClient::Paginating::Paginator.page_param = "page[number]"
+JsonApiClient::Paginating::Paginator.per_page_param = "page[size]"
+```
+
+Please note that this is a global configuration, so library authors should create a custom paginator that inherits `JsonApiClient::Paginating::Paginator` and configure the custom paginator to avoid modifying global config.
+
+If the [existing paginator](https://github.com/chingor13/json_api_client/blob/master/lib/json_api_client/paginating/paginator.rb) does not fit your needs, you can create a custom paginator:
+
 ```ruby
 class MyPaginator
   def initialize(result_set, data); end

--- a/lib/json_api_client/paginating/paginator.rb
+++ b/lib/json_api_client/paginating/paginator.rb
@@ -1,11 +1,18 @@
 module JsonApiClient
   module Paginating
     class Paginator
+      class_attribute :page_param,
+                      :per_page_param
+
+      self.page_param = "page"
+      self.per_page_param = "per_page"
+
       attr_reader :params, :result_set, :links
+
       def initialize(result_set, data)
         @params = params_for_uri(result_set.uri)
         @result_set = result_set
-        @links = data['links']
+        @links = data["links"]
       end
 
       def next
@@ -28,7 +35,7 @@ module JsonApiClient
         if links["last"]
           uri = result_set.links.link_url_for("last")
           last_params = params_for_uri(uri)
-          last_params.fetch("page") do
+          last_params.fetch(page_param) do
             current_page
           end.to_i
         else
@@ -47,13 +54,13 @@ module JsonApiClient
       end
 
       def per_page
-        params.fetch("per_page") do
+        params.fetch(per_page_param) do
           result_set.length
         end.to_i
       end
 
       def current_page
-        params.fetch("page", 1).to_i
+        params.fetch(page_param, 1).to_i
       end
 
       def out_of_bounds?


### PR DESCRIPTION
Similar to #188 but maintains backwards compatibility as requested.

Param keys can be configured with:

```ruby
JsonApiClient::Paginating::Paginator.configure do |config|
  config.page_param = "page[number]"
  config.per_page_param = "page[size]"
end
```

This PR adds a dependency on [dry-configurable](https://rubygems.org/gems/dry-configurable), I can remove this and implement it using plain old Ruby if desired.