### PR TITLE
Don't ignore 4XX errors, add BadRequest

### DIFF
--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -7,6 +7,12 @@ module JsonApiClient
       end
     end
 
+    class BadRequest < ApiError
+      def message
+        "Bad request"
+      end
+    end
+
     class ClientError < ApiError
     end
 

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -20,6 +20,8 @@ module JsonApiClient
       def handle_status(code, env)
         case code
         when 200..399
+        when 400
+          raise Errors::BadRequest, env
         when 401
           raise Errors::NotAuthorized, env
         when 403

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -31,7 +31,7 @@ module JsonApiClient
         when 409
           raise Errors::Conflict, env
         when 400..499
-          # some other error
+          raise Errors::UnexpectedStatus.new(code, env[:url])
         when 500..599
           raise Errors::ServerError, env
         else


### PR DESCRIPTION
I was very puzzled to find that unknown 4XX statuses are just silently
accepted. Additionally, BadRequest is something we use frequently in our API
for missing parameters and the like, so this adds explicit support for that as
well.