### PR TITLE
Allow custom ‘Accept’ header

### DIFF
--- a/lib/json_api_client/middleware/json_request.rb
+++ b/lib/json_api_client/middleware/json_request.rb
@@ -2,9 +2,24 @@ module JsonApiClient
   module Middleware
     class JsonRequest < Faraday::Middleware
       def call(environment)
+        accept_header = update_accept_header(environment[:request_headers])
+
         environment[:request_headers]["Content-Type"] = 'application/vnd.api+json'
-        environment[:request_headers]["Accept"] = 'application/vnd.api+json'
+        environment[:request_headers]["Accept"] = accept_header
         @app.call(environment)
+      end
+
+      private
+
+      def update_accept_header(headers)
+        return 'application/vnd.api+json' if headers["Accept"].nil?
+        accept_params = headers["Accept"].split(",")
+
+        unless accept_params.include?('application/vnd.api+json')
+          accept_params.unshift('application/vnd.api+json')
+        end
+
+        accept_params.join(",")
       end
     end
   end

--- a/test/unit/custom_header_test.rb
+++ b/test/unit/custom_header_test.rb
@@ -23,6 +23,24 @@ class CustomHeaderTest < MiniTest::Test
     end
   end
 
+  def test_can_set_custom_accept_headers
+    stub_request(:get, "http://example.com/custom_header_resources/1")
+      .with(headers: {"Accept" => "application/vnd.api+json,application/vnd.api+json;version=2"})
+      .to_return(headers: {accept: "application/vnd.api+json,application/vnd.api+json;version=2", content_type: "application/vnd.api+json"}, body: {
+        data: {
+          type: "custom_header_resources",
+          id: "1",
+          attributes: {
+            title: "My Blooming Test!"
+          }
+        }
+      }.to_json)
+
+    CustomHeaderResource.with_headers(accept: "application/vnd.api+json,application/vnd.api+json;version=2") do
+      CustomHeaderResource.find(1)
+    end
+  end
+
   def test_class_method_headers
     stub_request(:post, "http://example.com/custom_header_resources")
       .with(headers: {"X-My-Header" => "asdf"})


### PR DESCRIPTION
When using a versioned API that doesn't rely on path versioning, it's required that the `Accept` header is extended to include additional information, via multiple accept parameters. e..g:

    Accept: application/vnd.api+json, application/vnd.api+json; version=1

Have added the ability to override the `Accept` header, which will prepend with `application/vnd.api+json` should this string be missing as a standalone item.