### PR TITLE
Format belongs_to URLs

### DIFF
--- a/lib/json_api_client/associations/belongs_to.rb
+++ b/lib/json_api_client/associations/belongs_to.rb
@@ -16,13 +16,13 @@ module JsonApiClient
           :"#{attr_name}_id"
         end
 
-        def to_prefix_path
-          "#{attr_name.to_s.pluralize}/%{#{param}}"
+        def to_prefix_path(formatter)
+          "#{formatter.format(attr_name.to_s.pluralize)}/%{#{param}}"
         end
 
-        def set_prefix_path(attrs)
+        def set_prefix_path(attrs, formatter)
           attrs[param] = encode_part(attrs[param]) if attrs.key?(param)
-          to_prefix_path % attrs
+          to_prefix_path(formatter) % attrs
         end
       end
     end

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -263,11 +263,19 @@ module JsonApiClient
       end
 
       def _prefix_path
-        _belongs_to_associations.map(&:to_prefix_path).join("/")
+        paths = _belongs_to_associations.map do |a|
+          a.to_prefix_path(route_formatter)
+        end
+
+        paths.join("/")
       end
 
       def _set_prefix_path(attrs)
-        _belongs_to_associations.map { |a| a.set_prefix_path(attrs) }.join("/")
+        paths = _belongs_to_associations.map do |a|
+          a.set_prefix_path(attrs, route_formatter) 
+        end
+
+        paths.join("/")
       end
 
       def _new_scope

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -31,7 +31,33 @@ module Namespaced
   end
 end
 
+class Formatted < TestResource
+  def self.key_formatter
+    JsonApiClient::DasherizedKeyFormatter
+  end
+
+  def self.route_formatter
+    JsonApiClient::DasherizedRouteFormatter
+  end
+end
+
+class MultiWordParent < Formatted
+end
+
+class MultiWordChild < Formatted
+  belongs_to :multi_word_parent
+end
+
 class AssociationTest < MiniTest::Test
+
+  def test_belongs_to_urls_are_formatted
+    request = stub_request(:get, "http://example.com/multi-word-parents/1/multi-word-children")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: { data: [] }.to_json)
+
+    MultiWordChild.where(multi_word_parent_id: 1).to_a
+
+    assert_requested(request)
+  end
 
   def test_load_has_one
     stub_request(:get, "http://example.com/properties/1")


### PR DESCRIPTION
When using the dasherized formatter, I discovered that URLs created for belongs_to associations did not get dasherized. For example `.where(some_table_id: 5)` becomes `/some_table/5` rather than `/some-table/5`. This pull request fixes that issue.