### PR TITLE
Fix initializing resource including relationships

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -297,14 +297,16 @@ module JsonApiClient
       @persisted = nil
       self.links = self.class.linker.new(params.delete("links") || {})
       self.relationships = self.class.relationship_linker.new(self.class, params.delete("relationships") || {})
-      self.class.associations.each do |association|
-        if params.has_key?(association.attr_name.to_s)
-          set_attribute(association.attr_name, association.parse(params[association.attr_name.to_s]))
-        end
-      end
       self.attributes = params.merge(self.class.default_attributes)
+
       self.class.schema.each_property do |property|
         attributes[property.name] = property.default unless attributes.has_key?(property.name) || property.default.nil?
+      end
+
+      self.class.associations.each do |association|
+        if params.has_key?(association.attr_name.to_s)
+          set_attribute(association.attr_name, params[association.attr_name.to_s])
+        end
       end
     end
 

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -82,4 +82,11 @@ class ResourceTest < MiniTest::Test
       assert_equal("baz", article[:"foo-bar"])
     end
   end
+
+  def test_associations_as_params
+    article = Article.new(foo: 'bar', 'author' => {'type' => 'authors', 'id' => 1})
+    assert_equal(article.foo, 'bar')
+    assert_equal(article.attributes['author']['type'], 'authors')
+    assert_equal(article.attributes['author']['id'], 1)
+  end
 end


### PR DESCRIPTION
I was having an issue when loading a resource including relationships:
```
undefined method `parse' for #<JsonApiClient::Associations::HasOne::Association:0x0000000326c7f0>
     Shared Example Group: "jpi v1 protected action" called from ./spec/controllers/my_controller_spec.rb:37
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/resource.rb:302:in `block in initialize'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/resource.rb:300:in `each'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/resource.rb:300:in `initialize'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/resource.rb:95:in `new'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/resource.rb:95:in `load'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/parsers/parser.rb:69:in `block in handle_data'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/parsers/parser.rb:68:in `map'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/parsers/parser.rb:68:in `handle_data'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/parsers/parser.rb:12:in `block in parse'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/parsers/parser.rb:8:in `tap'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/parsers/parser.rb:8:in `parse'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/query/requestor.rb:60:in `request'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/query/requestor.rb:27:in `get'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/query/builder.rb:104:in `find'
     # /.rvm/gems/ruby-2.3.3/gems/json_api_client-1.5.1/lib/json_api_client/query/builder.rb:92:in `to_a'
```

Running the gem specs I realised this bit of code was not covered.