### PR TITLE
allows sparse fieldsets for multiple resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ article.title
 # should not have returned the created_at
 article.created_at
 # => raise NoMethodError
+
+# or you can use fieldsets from multiple resources
+# makes request to /articles?fields[articles]=title,body&fields[comments]=tag
+article = Article.select("title", "body",{comments: 'tag'}).first
 ```
 
 ## Sorting
@@ -485,7 +489,7 @@ class MyMoneyCaster
     end
   end
 end
-   
+
 JsonApiClient::Schema.register money: MyMoneyCaster
 
 ```

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -132,4 +132,41 @@ class QueryBuilderTest < MiniTest::Test
     Article.select(:title, :body).to_a
   end
 
+  def test_can_select_nested_fields_using_hashes
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {fields: {articles: 'tags', comments: 'author'}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    Article.select({comments: :author}, :tags).to_a
+  end
+
+
+  def test_can_select_nested_fields_using_hashes_of_arrays
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {fields: {articles: 'tags', comments: 'author,text'}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    Article.select({comments: [:author, :text]}, :tags).to_a
+  end
+
+  def test_can_select_nested_fields_using_strings
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {fields: {articles: 'tags', comments: 'author,text'}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    Article.select({comments: ['author', 'text']}, :tags).to_a
+  end
+
+  def test_can_select_nested_fields_using_comma_separated_strings
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {fields: {articles: 'tags', comments: 'author,text'}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    Article.select({comments: 'author,text'}, :tags).to_a
+  end
+
 end


### PR DESCRIPTION
Currently, this gem doesn't support the full features of spare field sets made available by the JSONAPI standard.  The gem allows you to specify fields for the root resource, but does not allow you specify fields for side loaded, related resources.

This change allows uses to do just that, using hash syntax congruent with other query builder params found in the gem.

See the four new tests for examples.