### PR TITLE
Fixed: query builder respects custom pagination params

### DIFF
--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -47,12 +47,12 @@ module JsonApiClient
       end
 
       def page(number)
-        @pagination_params[:number] = number
+        @pagination_params[ klass.paginator.page_param ] = number
         self
       end
 
       def per(size)
-        @pagination_params[:size] = size
+        @pagination_params[ klass.paginator.per_page_param ] = size
         self
       end
 

--- a/test/unit/custom_paginator_params_test.rb
+++ b/test/unit/custom_paginator_params_test.rb
@@ -3,9 +3,8 @@ require 'test_helper'
 class CustomPaginatorTest < MiniTest::Test
 
   class CustomPaginator < JsonApiClient::Paginating::Paginator
-    def total_entries
-      42
-    end
+    self.page_param = 'pagina'
+    self.per_page_param = 'limit'
   end
 
   class Book < JsonApiClient::Resource
@@ -13,15 +12,14 @@ class CustomPaginatorTest < MiniTest::Test
     self.paginator = CustomPaginator
   end
 
-  def test_can_override
+  def test_can_override_query_param_names
     stub_request(:get, "http://example.com/books")
+      .with(query: {page: {pagina: 3, limit: 6}})
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)
 
-    books = Book.all
-    assert_equal 42, books.total_count
-    assert_equal 42, books.total_entries
+    Book.paginate(page: 3, per_page: 6).to_a
   end
 
 end

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -31,7 +31,7 @@ class QueryBuilderTest < MiniTest::Test
 
   def test_can_paginate
     stub_request(:get, "http://example.com/articles")
-      .with(query: {page: {number: 3, size: 6}})
+      .with(query: {page: {page: 3, per_page: 6}})
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
         data: []
       }.to_json)


### PR DESCRIPTION
Fixes an issue I was running into where the custom pagination params I set weren't being used when generating pagination queries.