### PR TITLE
Add error details to resource when destroy fails

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -410,7 +410,7 @@ module JsonApiClient
       end
 
       if last_result_set.has_errors?
-        fill_errors(last_result_set)
+        fill_errors
         false
       else
         self.errors.clear if self.errors
@@ -431,7 +431,7 @@ module JsonApiClient
     def destroy
       self.last_result_set = self.class.requestor.destroy(self)
       if last_result_set.has_errors?
-        fill_errors(last_result_set)
+        fill_errors
         false
       else
         self.attributes.clear
@@ -500,7 +500,7 @@ module JsonApiClient
       relationships.as_json_api
     end
 
-    def fill_errors(last_result_set)
+    def fill_errors
       last_result_set.errors.each do |error|
         if error.source_parameter
           errors.add(self.class.key_formatter.unformat(error.source_parameter), error.title || error.detail)

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -410,13 +410,7 @@ module JsonApiClient
       end
 
       if last_result_set.has_errors?
-        last_result_set.errors.each do |error|
-          if error.source_parameter
-            errors.add(self.class.key_formatter.unformat(error.source_parameter), error.title || error.detail)
-          else
-            errors.add(:base, error.title || error.detail)
-          end
-        end
+        fill_errors(last_result_set)
         false
       else
         self.errors.clear if self.errors
@@ -436,11 +430,12 @@ module JsonApiClient
     # @return [Boolean] Whether or not the destroy succeeded
     def destroy
       self.last_result_set = self.class.requestor.destroy(self)
-      if !last_result_set.has_errors?
+      if last_result_set.has_errors?
+        fill_errors(last_result_set)
+        false
+      else
         self.attributes.clear
         true
-      else
-        false
       end
     end
 
@@ -503,6 +498,16 @@ module JsonApiClient
 
     def relationships_for_serialization
       relationships.as_json_api
+    end
+
+    def fill_errors(last_result_set)
+      last_result_set.errors.each do |error|
+        if error.source_parameter
+          errors.add(self.class.key_formatter.unformat(error.source_parameter), error.title || error.detail)
+        else
+          errors.add(:base, error.title || error.detail)
+        end
+      end
     end
   end
 end

--- a/test/unit/destroying_test.rb
+++ b/test/unit/destroying_test.rb
@@ -43,18 +43,23 @@ class DestroyingTest < MiniTest::Test
     assert(user.persisted?)
 
     stub_request(:delete, "http://example.com/users/1")
-      .to_return(headers: {content_type: "application/json"}, body: {
+      .to_return(headers: { content_type: "application/json" }, body: {
         data: [],
-        errors: [{
-          status: 400,
-          errors: [
-            {title: "Some failure message"}
-          ]
-        }]
+        errors: [
+          {
+            status: 400,
+            title: "Some failure message",
+            source: {
+              pointer: "/data/attributes/email_address"
+            }
+          }
+        ]
       }.to_json)
 
     assert_equal(false, user.destroy, "failed deletion should return falsy value")
     assert_equal(true, user.persisted?, "user should still be persisted because destroy failed")
+    assert(user.errors.present?)
+    assert_equal("Some failure message", user.errors.messages[:email_address].first, "user should contain the errors describing the failure")
   end
 
   def test_callbacks


### PR DESCRIPTION
Currently, if destroy fails, there is no easy way to retrieve the cause.
For example
`user.destroy` may returns false, and `user.errors` will be empty.
I think it should act the same way as `save`.