### PR TITLE
correct handling of errors with source/pointer "/data"

### DIFF
--- a/lib/json_api_client/error_collector.rb
+++ b/lib/json_api_client/error_collector.rb
@@ -33,18 +33,27 @@ module JsonApiClient
       end
 
       def source_parameter
-        source.fetch(:parameter) do
-          source[:pointer] ?
-            source[:pointer].split("/").last :
-            nil
-        end
+        source[:parameter]
       end
 
       def source_pointer
-        source.fetch(:pointer) do
-          source[:parameter] ?
-            "/data/attributes/#{source[:parameter]}" :
-            nil
+        source[:pointer]
+      end
+
+      def error_key
+        if source_pointer && source_pointer != "/data"
+          source_pointer.split("/").last
+        else
+          "base"
+        end
+      end
+
+      def error_msg
+        msg = title || detail || "invalid"
+        if source_parameter
+          "#{source_parameter} #{msg}"
+        else
+          msg
         end
       end
 
@@ -74,7 +83,7 @@ module JsonApiClient
 
     def [](source)
       map do |error|
-        error.source_parameter == source
+        error.error_key == source
       end
     end
 

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -411,11 +411,8 @@ module JsonApiClient
 
       if last_result_set.has_errors?
         last_result_set.errors.each do |error|
-          if error.source_parameter
-            errors.add(self.class.key_formatter.unformat(error.source_parameter), error.title || error.detail)
-          else
-            errors.add(:base, error.title || error.detail)
-          end
+          key = self.class.key_formatter.unformat(error.error_key)
+          errors.add(key, error.error_msg)
         end
         false
       else

--- a/test/unit/error_collector_test.rb
+++ b/test/unit/error_collector_test.rb
@@ -94,6 +94,9 @@ class ErrorCollectorTest < MiniTest::Test
     assert article.errors.present?
     assert_equal 2, article.errors.size
 
+    assert_equal ["Email address is invalid."], article.errors[:email_address]
+    assert_equal ["Title already taken"], article.errors[:base]
+
     error = article.last_result_set.errors.first
     assert_equal "1234-abcd", error.id
     assert_equal "http://example.com/help/errors/1337", error.about
@@ -102,7 +105,7 @@ class ErrorCollectorTest < MiniTest::Test
     assert_equal "Email address is invalid.", error.title
     assert_equal "Email address 'bar' is not a valid email address.", error.detail
     assert_equal "/data/attributes/email_address", error.source_pointer
-    assert_equal "email_address", error.source_parameter
+    assert_nil error.source_parameter
     assert error.meta.is_a?(JsonApiClient::MetaData)
     assert_equal "asdf", error.meta.qwer
 
@@ -116,6 +119,100 @@ class ErrorCollectorTest < MiniTest::Test
     assert_nil error.source_pointer
     assert_nil error.source_parameter
     assert error.meta.is_a?(JsonApiClient::MetaData)
+  end
+
+  def test_can_handle_generic_error
+    stub_request(:post, "http://example.com/articles")
+        .with(headers: {content_type: "application/vnd.api+json", accept: "application/vnd.api+json"}, body: {
+            data: {
+                type: "articles",
+                attributes: {
+                    title: "Rails is Omakase",
+                    email_address: "bar"
+                }
+            }
+        }.to_json)
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+            errors: [
+                {
+                    id: "1234-abcd",
+                    status: "422",
+                    code: "1337",
+                    title: "You can't create this record",
+                    detail: "You can't create this record",
+                    source: {
+                        pointer: "/data"
+                    }
+                }
+            ]
+        }.to_json)
+
+    article = Article.create({
+                                 title: "Rails is Omakase",
+                                 email_address: "bar"
+                             })
+    refute article.persisted?
+    assert article.errors.present?
+    assert_equal 1, article.errors.size
+
+    assert_equal ["You can't create this record"], article.errors[:base]
+
+    error = article.last_result_set.errors.first
+    assert_equal "1234-abcd", error.id
+    assert_nil error.about
+    assert_equal "422", error.status
+    assert_equal "1337", error.code
+    assert_equal "You can't create this record", error.title
+    assert_equal "You can't create this record", error.detail
+    assert_equal "/data", error.source_pointer
+    assert_nil error.source_parameter
+  end
+
+  def test_can_handle_parameter_error
+    stub_request(:post, "http://example.com/articles")
+        .with(headers: {content_type: "application/vnd.api+json", accept: "application/vnd.api+json"}, body: {
+            data: {
+                type: "articles",
+                attributes: {
+                    title: "Rails is Omakase",
+                    email_address: "bar"
+                }
+            }
+        }.to_json)
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+            errors: [
+                {
+                    id: "1234-abcd",
+                    status: "400",
+                    code: "1337",
+                    title: "bar is required",
+                    detail: "bar include is required for creation",
+                    source: {
+                        parameter: "include"
+                    }
+                }
+            ]
+        }.to_json)
+
+    article = Article.create({
+                                 title: "Rails is Omakase",
+                                 email_address: "bar"
+                             })
+    refute article.persisted?
+    assert article.errors.present?
+    assert_equal 1, article.errors.size
+
+    assert_equal ["include bar is required"], article.errors[:base]
+
+    error = article.last_result_set.errors.first
+    assert_equal "1234-abcd", error.id
+    assert_nil error.about
+    assert_equal "400", error.status
+    assert_equal "1337", error.code
+    assert_equal "bar is required", error.title
+    assert_equal "bar include is required for creation", error.detail
+    assert_nil error.source_pointer
+    assert_equal "include", error.source_parameter
   end
 
   def test_can_handle_explicit_null_error_values
@@ -151,6 +248,8 @@ class ErrorCollectorTest < MiniTest::Test
       assert !article.persisted?
       assert article.errors.present?
       assert_equal 1, article.errors.size
+
+      assert_equal ["invalid"], article.errors[:base]
 
       error = article.last_result_set.errors.first
       assert_equal "1337", error.id


### PR DESCRIPTION
http://jsonapi.org/format/#error-objects
 * source: an object containing references to the source of the error, optionally including any of the following members:
   * pointer: a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].
   * parameter: a string indicating which URI query parameter caused the error.

so source/pointer and source/parameter is a different things, and they should be handled in a different way

also error for pointer `/data` should be handled as `base` error for `ActiveModel::Errors` object